### PR TITLE
Initial refactor/modularization of Svelte stores.

### DIFF
--- a/src/components/Dashboard.svelte
+++ b/src/components/Dashboard.svelte
@@ -14,9 +14,9 @@
     storeConnected,
     storeMsaInfo,
     storeToken,
-    storeValidAccounts,
     transactionSigningAddress,
   } from '$lib/stores';
+  import { storeValidAccounts } from '$lib/stores/accountsStore';
 
   const onChangeTxnSigningAddress = (evt: Event) => {
     let option = evt.target as HTMLOptionElement;

--- a/src/components/Stake.svelte
+++ b/src/components/Stake.svelte
@@ -4,9 +4,9 @@
     storeCurrentAction,
     storeMsaInfo,
     storeToken,
-    storeValidAccounts,
     transactionSigningAddress,
   } from '$lib/stores';
+  import { storeValidAccounts } from '$lib/stores/accountsStore';
   import type { ApiPromise } from '@polkadot/api';
   import { DOLLARS, submitStake } from '$lib/connections';
   import { ActionForms, defaultDotApi } from '$lib/storeTypes';

--- a/src/lib/polkadotApi.ts
+++ b/src/lib/polkadotApi.ts
@@ -5,9 +5,8 @@ import {
   storeBlockNumber,
   storeConnected,
   storeToken,
-  storeValidAccounts,
 } from './stores';
-import { storeProviderAccounts } from './stores/accountsStore';
+import { storeProviderAccounts, storeValidAccounts } from './stores/accountsStore';
 import { isLocalhost } from './utils';
 import { options } from '@frequency-chain/api-augment';
 
@@ -19,7 +18,7 @@ import type { ChainProperties } from '@polkadot/types/interfaces';
 import type { Option, u64 } from '@polkadot/types';
 
 export type AccountMap = Record<string, KeyringPair>;
-type MetaMap = Record<string, InjectedAccountWithMeta>;
+export type MetaMap = Record<string, InjectedAccountWithMeta>;
 
 export async function getApi(selectedProviderURI: string, thisDotApi: DotApi, wsProvider: WsProvider) {
   if (!selectedProviderURI) {

--- a/src/lib/polkadotApi.ts
+++ b/src/lib/polkadotApi.ts
@@ -6,8 +6,8 @@ import {
   storeConnected,
   storeToken,
   storeValidAccounts,
-  storeProviderAccounts,
 } from './stores';
+import { storeProviderAccounts } from './stores/accountsStore';
 import { isLocalhost } from './utils';
 import { options } from '@frequency-chain/api-augment';
 

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -1,12 +1,9 @@
 import { writable, type Writable } from 'svelte/store';
 import { ActionForms, defaultDotApi, type MsaInfo } from '$lib/storeTypes';
-
 export const storeConnected = writable(false);
 
 //All accounts
 export const storeValidAccounts = writable({});
-//Only provider accounts
-export const storeProviderAccounts = writable({});
 
 export const transactionSigningAddress = writable('');
 
@@ -21,22 +18,4 @@ export const storeToken = writable('');
 
 export const storeChainInfo = writable({ connected: false, blockNumber: 0n, epochNumber: 0n, token: '' });
 
-export enum PageContent {
-  Dashboard = 'dashboard',
-  Login = 'login',
-  BecomeProvider = 'becomeProvider',
-}
-
-const createPageContentStore = () => {
-  const { subscribe, set, update } = writable(PageContent.Login);
-
-  return {
-    subscribe,
-    set,
-    login: () => set(PageContent.Login),
-    becomeProvider: () => set(PageContent.BecomeProvider),
-    dashboard: () => set(PageContent.Dashboard),
-  };
-};
-
-export const pageContent = createPageContentStore();
+export const isLoggedIn = writable(false);

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -2,9 +2,6 @@ import { writable, type Writable } from 'svelte/store';
 import { ActionForms, defaultDotApi, type MsaInfo } from '$lib/storeTypes';
 export const storeConnected = writable(false);
 
-//All accounts
-export const storeValidAccounts = writable({});
-
 export const transactionSigningAddress = writable('');
 
 export const storeMsaInfo: Writable<MsaInfo | undefined> = writable();

--- a/src/lib/stores/accountsStore.ts
+++ b/src/lib/stores/accountsStore.ts
@@ -1,0 +1,55 @@
+import { writable, type Writable } from 'svelte/store';
+import { ApiPromise, Keyring } from '@polkadot/api';
+import type { web3Enable, web3Accounts } from '@polkadot/extension-dapp';
+import type { AccountMap, MetaMap } from '$lib/polkadotApi';
+import { getMsaInfo } from '$lib/polkadotApi';
+import { Network, networkToInfo } from '$lib/stores/networksStore';
+import { isFunction } from '@polkadot/util';
+
+//Only provider accounts
+export const storeProviderAccounts = writable({});
+
+export async function fetchAccounts(
+  selectedNetwork: Network,
+  thisWeb3Enable: typeof web3Enable,
+  thisWeb3Accounts: typeof web3Accounts,
+  apiPromise: ApiPromise
+) {
+  console.log('fetchAccounts() - ', selectedNetwork);
+  const selectedNetworkInfo = networkToInfo[selectedNetwork];
+  // populating for localhost and for a parachain are different since with localhost, there is
+  // access to the Alice/Bob/Charlie accounts etc., and so won't use the extension.
+  let foundAccounts: AccountMap | MetaMap = {}; // eslint-disable-line prefer-const
+  if (selectedNetwork === Network.LOCALHOST) {
+    const keyring = new Keyring({ type: 'sr25519' });
+
+    ['//Alice', '//Bob', '//Charlie', '//Dave', '//Eve', '//Ferdie'].forEach((accountName) => {
+      const account = { ...keyring.addFromUri(accountName), ...{ meta: { name: accountName } } };
+      foundAccounts[account.address] = account;
+    });
+  }
+  // If the Polkadot extension is installed, add the accounts to the list
+  if (isFunction(thisWeb3Accounts) && isFunction(thisWeb3Enable)) {
+    const extensions = await thisWeb3Enable('Frequency parachain provider dashboard');
+    if (!extensions || !extensions.length) {
+      alert('Polkadot{.js} extension not found; please install it first.');
+      throw new Error('Polkadot{.js} extension not found; please install it first.');
+    }
+
+    const allAccounts = await thisWeb3Accounts();
+    allAccounts.forEach((a) => {
+      // include only the accounts allowed for this chain
+      if (!a.meta.genesisHash || selectedNetworkInfo.genesisHash === a.meta.genesisHash) {
+        foundAccounts[a.address] = a;
+      }
+    });
+  }
+
+  const foundProviderAccounts: AccountMap | MetaMap = {};
+  for (const index in Object.keys(foundAccounts)) {
+    const account = Object.values(foundAccounts)[index];
+    const { isProvider } = await getMsaInfo(apiPromise, account.address);
+    if (isProvider) foundProviderAccounts[account.address] = account;
+  }
+  storeProviderAccounts.set(foundProviderAccounts);
+}

--- a/src/lib/stores/accountsStore.ts
+++ b/src/lib/stores/accountsStore.ts
@@ -6,6 +6,8 @@ import { getMsaInfo } from '$lib/polkadotApi';
 import { Network, networkToInfo } from '$lib/stores/networksStore';
 import { isFunction } from '@polkadot/util';
 
+//All accounts
+export const storeValidAccounts = writable({});
 //Only provider accounts
 export const storeProviderAccounts = writable({});
 

--- a/src/lib/stores/networksStore.ts
+++ b/src/lib/stores/networksStore.ts
@@ -1,0 +1,54 @@
+import { writable, type Writable } from 'svelte/store';
+
+/**
+ * Represents the available networks.
+ */
+export enum Network {
+  NONE = 'NONE',
+  TESTNET = 'TESTNET',
+  MAINNET = 'MAINNET',
+  LOCALHOST = 'LOCALHOST',
+  CUSTOM = 'CUSTOM',
+}
+
+/**
+ * Represents information about a network.
+ */
+export interface NetworkInfo {
+  name: string | undefined;
+  endpoint: URL | undefined;
+  genesisHash: string | undefined;
+}
+
+/**
+ * Mapping of network types to network information.
+ */
+export const networkToInfo: Record<Network, NetworkInfo> = {
+  NONE: { name: undefined, endpoint: undefined, genesisHash: undefined },
+  TESTNET: {
+    name: 'TESTNET',
+    endpoint: new URL('wss://rpc.rococo.frequency.xyz'),
+    genesisHash: '0x0c33dfffa907de5683ae21cc6b4af899b5c4de83f3794ed75b2dc74e1b088e72',
+  },
+  MAINNET: {
+    name: 'MAINNET',
+    endpoint: new URL('wss://0.rpc.frequency.xyz'),
+    genesisHash: '0x4a587bf17a404e3572747add7aab7bbe56e805a5479c6c436f07f36fcc8d3ae1',
+  },
+  LOCALHOST: { name: 'LOCALHOST', endpoint: new URL('ws://127.0.0.1:9944'), genesisHash: undefined },
+  CUSTOM: { name: 'CUSTOM', endpoint: new URL('ws://127.0.0.1:9944'), genesisHash: undefined },
+};
+
+/**
+ * The selected network.
+ */
+export const selectedNetwork = writable(Network.NONE);
+
+export function allNetworks(): Record<string, string> {
+  return Object.entries(networkToInfo).reduce((acc: Record<string, string>, [key, value]) => {
+    if (key !== Network.NONE) {
+      acc[key] = `${value.name}: ${value.endpoint?.toString().replace(/\/$/, '')}`;
+    }
+    return acc;
+  }, {});
+}

--- a/src/lib/stores/pageContentStore.ts
+++ b/src/lib/stores/pageContentStore.ts
@@ -1,0 +1,23 @@
+import { writable, type Writable } from 'svelte/store';
+
+export enum PageContent {
+  Dashboard = 'dashboard',
+  Login = 'login',
+  BecomeProvider = 'becomeProvider',
+  Reconnect = 'reconnect',
+}
+
+const createPageContentStore = () => {
+  const { subscribe, set } = writable(PageContent.Login);
+
+  return {
+    subscribe,
+    set,
+    login: () => set(PageContent.Login),
+    becomeProvider: () => set(PageContent.BecomeProvider),
+    dashboard: () => set(PageContent.Dashboard),
+    reconnect: () => set(PageContent.Reconnect),
+  };
+};
+
+export const pageContent = createPageContentStore();

--- a/src/lib/stores/pageContentStore.ts
+++ b/src/lib/stores/pageContentStore.ts
@@ -4,7 +4,6 @@ export enum PageContent {
   Dashboard = 'dashboard',
   Login = 'login',
   BecomeProvider = 'becomeProvider',
-  Reconnect = 'reconnect',
 }
 
 const createPageContentStore = () => {
@@ -16,7 +15,6 @@ const createPageContentStore = () => {
     login: () => set(PageContent.Login),
     becomeProvider: () => set(PageContent.BecomeProvider),
     dashboard: () => set(PageContent.Dashboard),
-    reconnect: () => set(PageContent.Reconnect),
   };
 };
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,7 +2,7 @@
   import Dashboard from '$components/Dashboard.svelte';
   import RequestToBeProvider from '$components/RequestToBeProvider.svelte';
   import ProviderLogin from '$components/ProviderLogin.svelte';
-  import { pageContent, PageContent } from '$lib/stores';
+  import { pageContent, PageContent } from '$lib/stores/pageContentStore';
 
   $pageContent = PageContent.Dashboard;
 </script>


### PR DESCRIPTION
Initial refactoring of the Svelte stores
- There are now separate stores for networks and accounts.
- There is a page content store to manage which component is displayed.  This is one approach to managing content but we can explore others if needed.
- There is an `isLoggedIn` store to distinguish between a user who has never logged in vs. one who is switching their login.  This may be a temporary placeholder until and if we later change the underlying model.