### PR TITLE
add controll key modal, styling, and funcitonality

### DIFF
--- a/src/components/AddControlKey.svelte
+++ b/src/components/AddControlKey.svelte
@@ -111,7 +111,7 @@
         formatter={formatAccount}
       />
       {#if $unusedKeyAccountsStore.size === 0}
-        <div id="network-error-msg" class="text-error text-sm">
+        <div id="network-error-msg" class="text-sm text-error">
           No available keys. Create a new account without an MSA Id.
         </div>
       {/if}

--- a/src/components/AddControlKey.svelte
+++ b/src/components/AddControlKey.svelte
@@ -26,7 +26,7 @@
 
   let showTransactionStatus = false;
 
-  $: isDisabled = selectedAccount?.signingKey == null || showTransactionStatus;
+  $: isSubmitDisabled = selectedAccount?.signingKey == null || showTransactionStatus;
 
   onMount(async () => {
     const extension = await import('@polkadot/extension-dapp');
@@ -40,11 +40,14 @@
   const clearTxnStatuses = () => (txnStatuses = new Array<string>());
 
   const addControlKey = async () => {
-    if (!$user.msaId || !$user.signingKey) throw new Error('Provider MSA Id not connected.');
     clearTxnStatuses();
+
     let endpointURI: string = $dotApi.selectedEndpoint || '';
-    if (!selectedAccount.signingKey) {
+
+    if (!selectedAccount || !selectedAccount.signingKey) {
       alert('Please choose a key to add.');
+    } else if (!$user.msaId || !$user.signingKey) {
+      alert('Invalid provider.');
     } else {
       let newKeys: SigningKey = selectedAccount.signingKey;
       let signingKeys: SigningKey = $user.signingKey;
@@ -111,12 +114,12 @@
         formatter={formatAccount}
       />
       {#if $unusedKeyAccountsStore.size === 0}
-        <div id="network-error-msg" class="text-sm text-error">
+        <div id="network-error-msg" class="text-error text-sm">
           No available keys. Create a new account without an MSA Id.
         </div>
       {/if}
       <div class="flex w-[350px] justify-between">
-        <button on:click|preventDefault={addControlKey} class="btn-primary" disabled={isDisabled}>Add Key</button>
+        <button on:click|preventDefault={addControlKey} class="btn-primary" disabled={isSubmitDisabled}>Add Key</button>
         <button on:click|preventDefault={onCancel} class="btn-no-fill">Cancel</button>
       </div>
     </form>

--- a/src/components/AddControlKey.svelte
+++ b/src/components/AddControlKey.svelte
@@ -114,7 +114,7 @@
         formatter={formatAccount}
       />
       {#if $unusedKeyAccountsStore.size === 0}
-        <div id="network-error-msg" class="text-error text-sm">
+        <div id="network-error-msg" class="text-sm text-error">
           No available keys. Create a new account without an MSA Id.
         </div>
       {/if}

--- a/src/components/AddKeyRequirements.svelte
+++ b/src/components/AddKeyRequirements.svelte
@@ -1,0 +1,18 @@
+<div>
+  <div class="label mb-2">Requirements</div>
+  <ol class="ordered-list text-xs">
+    <li>
+      Ensure the new control key has a FRQCY balance if you intend to use it for submitting FRQCY or Capacity
+      transactions.
+    </li>
+    <li>If using a wallet, ensure the new control key is imported into your wallet.</li>
+    <li>Select the new control key from the dropdown list below.</li>
+    <li>Click 'Add It.'</li>
+    <li>This requires 3 signatures: two for the authorization payload, and one to send the transaction.</li>
+    <ul class="unordered-list">
+      <li>Sign with the new control key,</li>
+      <li>Sign with the current control key,</li>
+      <li>Sign the transaction with the current control key.</li>
+    </ul>
+  </ol>
+</div>

--- a/src/components/ConnectProvider.svelte
+++ b/src/components/ConnectProvider.svelte
@@ -5,7 +5,7 @@
   import DropDownMenu from './DropDownMenu.svelte';
 </script>
 
-<Modal {close} {isOpen}>
+<Modal id="conntect-provider" {close} {isOpen}>
   <div class="flex flex-col gap-7">
     <h2 class="section-title-underlined">Connect Provider</h2>
     <!-- Select a network dropdown goes here -->

--- a/src/components/Modal.svelte
+++ b/src/components/Modal.svelte
@@ -1,15 +1,17 @@
 <script lang="ts">
+  export let id: string;
   export let close = () => {};
   export let isOpen: boolean = false;
 </script>
 
 {#if isOpen}
   <div
+    {id}
     on:click={close}
     on:keyup={close}
     role="button"
     tabindex="0"
-    class="fixed right-0 top-0 z-[100] flex h-[100vh] w-[calc(100vw-126px)] cursor-default items-center justify-center bg-overlay"
+    class="fixed right-0 top-0 z-[100] flex h-[100vh] w-[calc(100vw-126px)] cursor-default items-center justify-center overflow-y-auto bg-overlay"
   >
     <div
       class="content-block w-modal cursor-default"

--- a/src/components/Provider.svelte
+++ b/src/components/Provider.svelte
@@ -5,20 +5,17 @@
   import { getBalances } from '$lib/polkadotApi';
   import type { AccountBalances } from '$lib/polkadotApi';
   import ListCard from './ListCard.svelte';
-  import { ActionForms } from '$lib/storeTypes.js';
   import { onMount } from 'svelte';
+  import AddControlKey from './AddControlKey.svelte';
 
   let accountBalances: AccountBalances = { free: 0n, reserved: 0n, frozen: 0n };
+  let isAddKeyOpen: boolean = false;
 
   onMount(async () => {
     if ($dotApi.api) {
       accountBalances = await getBalances($dotApi.api, $user.address);
     }
   });
-
-  function showAddControlKey() {
-    storeCurrentAction.set(ActionForms.AddControlKey);
-  }
 
   let providerList: { label: string; value: string }[] = [];
   let errMsg: string = '';
@@ -47,5 +44,6 @@
 </script>
 
 <ListCard title="Provider" list={providerList} errorMessage={errMsg}>
-  <button on:click|preventDefault={showAddControlKey} class="btn-primary">Add control key</button>
+  <button on:click|preventDefault={() => (isAddKeyOpen = true)} class="btn-primary">Add control key</button>
+  <AddControlKey isOpen={isAddKeyOpen} close={() => (isAddKeyOpen = false)} />
 </ListCard>

--- a/src/components/TransactionStatus.svelte
+++ b/src/components/TransactionStatus.svelte
@@ -8,12 +8,12 @@
   };
 </script>
 
-<div class:hidden={!showSelf} id="transaction-status" class="action-card grow-1 ml-8 basis-1/3">
-  <p class="action-card-title">Transaction status</p>
-  <ul class="">
+<div class:hidden={!showSelf} id="transaction-status" class="">
+  <p class="label">Transaction Status</p>
+  <ul class="unordered-list break-words text-sm">
     {#each statuses as status}
-      <li class="text-md mt-4 font-light">{status}</li>
+      <li class="">{status}</li>
     {/each}
   </ul>
-  <button on:click|preventDefault={hideSelf} class="btn-primary">Dismiss Status</button>
+  <button on:click|preventDefault={hideSelf} class="btn-no-fill mt-4 justify-end">Dismiss Status</button>
 </div>

--- a/src/lib/connections.ts
+++ b/src/lib/connections.ts
@@ -40,7 +40,7 @@ export async function submitAddControlKey(
   extension: InjectedExtension | undefined,
   newAccount: SigningKey,
   signingAccount: SigningKey,
-  providerId: number,
+  msaId: number,
   endpointURL: string,
   txnStatusCallback: TxnStatusCallback,
   txnFinishedCallback: TxnFinishedCallback
@@ -48,7 +48,7 @@ export async function submitAddControlKey(
   const blockNumber = (await getBlockNumber(api)) as bigint;
   if (api && (await api.isReady)) {
     const rawPayload: AddKeyData = {
-      msaId: providerId.toString(),
+      msaId: msaId.toString(),
       expiration: (blockNumber + 100n).toString(),
       newPublicKey: newAccount.address,
     };

--- a/src/lib/connections.ts
+++ b/src/lib/connections.ts
@@ -125,7 +125,7 @@ export type TxnFinishedCallback = (succeeded: boolean) => void;
 
 // log and call the callback with the status.
 function showExtrinsicStatus(txnStatus: string, cb: TxnStatusCallback) {
-  console.debug('Transaction status: ', txnStatus);
+  console.debug('Transaction Status: ', txnStatus);
   cb(txnStatus);
 }
 

--- a/src/lib/stores/accountsStore.ts
+++ b/src/lib/stores/accountsStore.ts
@@ -28,6 +28,7 @@ export type Accounts = Map<SS58Address, Readonly<Account>>;
 
 export const providerAccountsStore = writable<Accounts>(new Map<SS58Address, Readonly<Account>>());
 export const nonProviderAccountsStore = writable<Accounts>(new Map<SS58Address, Readonly<Account>>());
+export const unusedKeyAccountsStore = writable<Accounts>(new Map<SS58Address, Readonly<Account>>());
 
 export async function fetchAccountsForNetwork(
   selectedNetwork: NetworkInfo,
@@ -39,6 +40,7 @@ export async function fetchAccountsForNetwork(
 
   const providerAccounts: Accounts = new Map<SS58Address, Account>();
   const nonProviderAccounts: Accounts = new Map<SS58Address, Account>();
+  const unusedKeyAccounts: Accounts = new Map<SS58Address, Account>();
 
   // If the network is localhost, add the default test accounts for the chain
   if (selectedNetwork.name === 'LOCALHOST') {
@@ -58,6 +60,9 @@ export async function fetchAccountsForNetwork(
         if (account.isProvider) {
           providerAccounts.set(account.address, account);
         } else {
+          if (account.msaId === 0) {
+            unusedKeyAccounts.set(account.address, account);
+          }
           nonProviderAccounts.set(account.address, account);
         }
       })
@@ -88,6 +93,9 @@ export async function fetchAccountsForNetwork(
           if (account.isProvider) {
             providerAccounts.set(account.address, account);
           } else {
+            if (account.msaId === 0) {
+              unusedKeyAccounts.set(account.address, account);
+            }
             nonProviderAccounts.set(account.address, account);
           }
         }
@@ -97,4 +105,5 @@ export async function fetchAccountsForNetwork(
 
   providerAccountsStore.set(providerAccounts);
   nonProviderAccountsStore.set(nonProviderAccounts);
+  unusedKeyAccountsStore.set(unusedKeyAccounts);
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -63,7 +63,7 @@ export function formatNetwork(network: NetworkInfo): string {
 }
 
 export function formatAccount(account: Account): string {
-  return account.address;
+  return `${account.providerName}${account.providerName && ':'} ${account.address}`;
 }
 
 // create a URL-encoded mailto URL string using the provided parameters.

--- a/test/unit-and-integration/connections.test.ts
+++ b/test/unit-and-integration/connections.test.ts
@@ -113,18 +113,18 @@ describe('submitAddControlKey', async () => {
     const api = await ApiPromise.create();
     const extension = undefined;
     const callback = vi.fn();
-    const providerId = 4;
+    const msaId = 4;
     const endpointURL = 'ws://localhost:9944';
-    await submitAddControlKey(api, extension, bob, alice, providerId, endpointURL, callback, callback);
+    await submitAddControlKey(api, extension, bob, alice, msaId, endpointURL, callback, callback);
     expect(callback).toHaveBeenCalled();
   });
   it('calls the callback when not localhost', async () => {
     const api = await ApiPromise.create();
     const extension = undefined;
     const callback = vi.fn();
-    const providerId = 4;
+    const msaId = 4;
     const endpointURL = 'ws://someotherhost:9944';
-    await submitAddControlKey(api, extension, bob, alice, providerId, endpointURL, callback, callback);
+    await submitAddControlKey(api, extension, bob, alice, msaId, endpointURL, callback, callback);
     expect(callback).toHaveBeenCalled();
   });
 });

--- a/test/unit-and-integration/createMsa.test.ts
+++ b/test/unit-and-integration/createMsa.test.ts
@@ -60,7 +60,7 @@ describe('CreateMsa component', () => {
   //   await waitFor(() => {
   //     expect(extrinsicWasCalled).toBe(true);
   //     expect(container.querySelector('#transaction-status')).not.toHaveClass('hidden');
-  //     expect(getByText('Transaction status')).toBeInTheDocument();
+  //     expect(getByText('Transaction Status')).toBeInTheDocument();
   //     expect(getByText('Submitting transaction')).toBeInTheDocument();
   //   });
   // });

--- a/test/unit-and-integration/createProvider.test.ts
+++ b/test/unit-and-integration/createProvider.test.ts
@@ -65,7 +65,7 @@ describe('CreateProvider component', () => {
     await waitFor(() => {
       expect(extrinsicWasCalled).toBe(true);
       expect(container.querySelector('#transaction-status')).not.toHaveClass('hidden');
-      expect(getByText('Transaction status')).toBeInTheDocument();
+      expect(getByText('Transaction Status')).toBeInTheDocument();
       expect(getByText('Submitting transaction')).toBeInTheDocument();
     });
   });

--- a/test/unit-and-integration/requestToBeProvider.test.ts
+++ b/test/unit-and-integration/requestToBeProvider.test.ts
@@ -29,7 +29,7 @@ describe('RequestToBeProvider component', () => {
     expect(mockCancelAction).toHaveBeenCalled();
   });
 
-  it('clicking Request To Be Provider submits extrinsic and shows Transaction status', async () => {
+  it('clicking Request To Be Provider submits extrinsic and shows Transaction Status', async () => {
     const user = userEvent.setup();
     const { container, getByRole, getByLabelText, getByText } = render(RequestToBeProvider, {
       cancelAction: mockCancelAction,
@@ -67,7 +67,7 @@ describe('RequestToBeProvider component', () => {
     await waitFor(() => {
       expect(extrinsicWasCalled).toBe(true);
       expect(container.querySelector('#transaction-status')).not.toHaveClass('hidden');
-      expect(getByText('Transaction status')).toBeInTheDocument();
+      expect(getByText('Transaction Status')).toBeInTheDocument();
       expect(getByText('Submitting transaction')).toBeInTheDocument();
     });
   });

--- a/test/unit-and-integration/stake.test.ts
+++ b/test/unit-and-integration/stake.test.ts
@@ -66,6 +66,6 @@ describe('Stake.svelte Unit Tests', () => {
 
     const button = screen.getByRole('button', { name: 'Stake' });
     await fireEvent.click(button);
-    expect(getByText('Transaction status')).toBeInTheDocument();
+    expect(getByText('Transaction Status')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
closes #88 

## Changes
- opt for using $ syntax instead of .subscribe() syntax in updated components
- Accounts store now filters and stores unusedKeyAccountsStore to be used in add key dropdown.
- wrap add control key component in Modal & open modal on add control key button click
- clear selected account and hide transaction status on cancel/close of modal
- separated requirements into it's own component.
- added error message if no available keys.
- disabled add key button in modal if transaction in progress or account not selected.
- added overflow scroll and text break to modal
- added minor styling to transaction status component.
- updates tests to read "Transaction Status" instead of "Transaction status"
- added provider name to format account function for better readability in dropdowns.

## How to test
- No accounts that are not providers or do not have MSA in wallet
  - expect to see error in modal.
- Has accounts that are not providers and do not have MSA in wallet
  - expect to be able to select account in dropdown.
  - IF NO FUNDS: display error in transaction status.
  - IF FUNDS: eventually display success.
- on cancel: should clear modal content
- on success: on login, should see new key associated with original account.