### PR TITLE
svelte store with local storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "@polkadot/types": "^10.11.2",
         "@polkadot/util": "^12.6.2",
         "jsdom": "^24.0.0",
-        "rxjs": "^7.8.1"
+        "rxjs": "^7.8.1",
+        "vite-tsconfig-paths": "^4.3.1"
       },
       "devDependencies": {
         "@polkadot/types-codec": "^10.11.2",
@@ -4550,7 +4551,7 @@
       "version": "0.18.11",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.11.tgz",
       "integrity": "sha512-i8u6mQF0JKJUlGR3OdFLKldJQMMs8OqM9Cc3UCi9XXziJ9WERM5bfkHaEAy0YAvPRMgqSW55W7xYn84XtEFTtA==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -5423,6 +5424,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
     },
     "node_modules/gopd": {
       "version": "1.0.1",
@@ -7855,7 +7861,7 @@
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
       "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -8247,7 +8253,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -8306,7 +8312,7 @@
       "version": "8.4.33",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
       "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8851,7 +8857,7 @@
       "version": "3.26.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.26.2.tgz",
       "integrity": "sha512-6umBIGVz93er97pMgQO08LuH3m6PUb3jlDUUGFsNJB6VgTCUaDFpupf5JfU30529m/UKOgmiX+uY6Sx8cOYpLA==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -9087,7 +9093,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9717,6 +9723,25 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true
     },
+    "node_modules/tsconfck": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.0.2.tgz",
+      "integrity": "sha512-6lWtFjwuhS3XI4HsX4Zg0izOI3FU/AI9EGVlPEUMDIhvLPMD4wkiof0WCoDgW7qY+Dy198g4d9miAqUHWHFH6Q==",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
@@ -9759,7 +9784,7 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9868,7 +9893,7 @@
       "version": "4.4.8",
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.8.tgz",
       "integrity": "sha512-LONawOUUjxQridNWGQlNizfKH89qPigK36XhMI7COMGztz8KNY0JHim7/xDd71CZwGT4HtSRgI7Hy+RlhG0Gvg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.26",
@@ -10599,6 +10624,24 @@
           "optional": true
         },
         "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-4.3.1.tgz",
+      "integrity": "sha512-cfgJwcGOsIxXOLU/nELPny2/LUD/lcf1IbfyeKTv2bsupVbTH/xpFtdQlBmIP1GEK2CjjLxYhFfB+QODFAx5aw==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.1"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
           "optional": true
         }
       }
@@ -14833,7 +14876,7 @@
       "version": "0.18.11",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.11.tgz",
       "integrity": "sha512-i8u6mQF0JKJUlGR3OdFLKldJQMMs8OqM9Cc3UCi9XXziJ9WERM5bfkHaEAy0YAvPRMgqSW55W7xYn84XtEFTtA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@esbuild/android-arm": "0.18.11",
         "@esbuild/android-arm64": "0.18.11",
@@ -15453,6 +15496,11 @@
         "merge2": "^1.4.1",
         "slash": "^3.0.0"
       }
+    },
+    "globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
     },
     "gopd": {
       "version": "1.0.1",
@@ -17264,7 +17312,7 @@
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
       "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
-      "dev": true
+      "devOptional": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -17536,7 +17584,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "devOptional": true
     },
     "picomatch": {
       "version": "2.3.1",
@@ -17580,7 +17628,7 @@
       "version": "8.4.33",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
       "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
@@ -17876,7 +17924,7 @@
       "version": "3.26.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.26.2.tgz",
       "integrity": "sha512-6umBIGVz93er97pMgQO08LuH3m6PUb3jlDUUGFsNJB6VgTCUaDFpupf5JfU30529m/UKOgmiX+uY6Sx8cOYpLA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "fsevents": "~2.3.2"
       }
@@ -18055,7 +18103,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true
+      "devOptional": true
     },
     "source-map-support": {
       "version": "0.5.13",
@@ -18482,6 +18530,12 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true
     },
+    "tsconfck": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.0.2.tgz",
+      "integrity": "sha512-6lWtFjwuhS3XI4HsX4Zg0izOI3FU/AI9EGVlPEUMDIhvLPMD4wkiof0WCoDgW7qY+Dy198g4d9miAqUHWHFH6Q==",
+      "requires": {}
+    },
     "tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
@@ -18512,7 +18566,7 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "dev": true
+      "devOptional": true
     },
     "ufo": {
       "version": "1.3.2",
@@ -18585,7 +18639,7 @@
       "version": "4.4.8",
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.8.tgz",
       "integrity": "sha512-LONawOUUjxQridNWGQlNizfKH89qPigK36XhMI7COMGztz8KNY0JHim7/xDd71CZwGT4HtSRgI7Hy+RlhG0Gvg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "esbuild": "^0.18.10",
         "fsevents": "~2.3.2",
@@ -18924,6 +18978,16 @@
             "rollup": "^4.2.0"
           }
         }
+      }
+    },
+    "vite-tsconfig-paths": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-4.3.1.tgz",
+      "integrity": "sha512-cfgJwcGOsIxXOLU/nELPny2/LUD/lcf1IbfyeKTv2bsupVbTH/xpFtdQlBmIP1GEK2CjjLxYhFfB+QODFAx5aw==",
+      "requires": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.1"
       }
     },
     "vitefu": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,7 @@
         "@polkadot/types": "^10.11.2",
         "@polkadot/util": "^12.6.2",
         "jsdom": "^24.0.0",
-        "rxjs": "^7.8.1",
-        "vite-tsconfig-paths": "^4.3.1"
+        "rxjs": "^7.8.1"
       },
       "devDependencies": {
         "@polkadot/types-codec": "^10.11.2",
@@ -4551,7 +4550,7 @@
       "version": "0.18.11",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.11.tgz",
       "integrity": "sha512-i8u6mQF0JKJUlGR3OdFLKldJQMMs8OqM9Cc3UCi9XXziJ9WERM5bfkHaEAy0YAvPRMgqSW55W7xYn84XtEFTtA==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -5424,11 +5423,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/globrex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
     },
     "node_modules/gopd": {
       "version": "1.0.1",
@@ -7861,7 +7855,7 @@
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
       "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8253,7 +8247,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -8312,7 +8306,7 @@
       "version": "8.4.33",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
       "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8857,7 +8851,7 @@
       "version": "3.26.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.26.2.tgz",
       "integrity": "sha512-6umBIGVz93er97pMgQO08LuH3m6PUb3jlDUUGFsNJB6VgTCUaDFpupf5JfU30529m/UKOgmiX+uY6Sx8cOYpLA==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -9093,7 +9087,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9723,25 +9717,6 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true
     },
-    "node_modules/tsconfck": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.0.2.tgz",
-      "integrity": "sha512-6lWtFjwuhS3XI4HsX4Zg0izOI3FU/AI9EGVlPEUMDIhvLPMD4wkiof0WCoDgW7qY+Dy198g4d9miAqUHWHFH6Q==",
-      "bin": {
-        "tsconfck": "bin/tsconfck.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
@@ -9784,7 +9759,7 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9893,7 +9868,7 @@
       "version": "4.4.8",
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.8.tgz",
       "integrity": "sha512-LONawOUUjxQridNWGQlNizfKH89qPigK36XhMI7COMGztz8KNY0JHim7/xDd71CZwGT4HtSRgI7Hy+RlhG0Gvg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.26",
@@ -10624,24 +10599,6 @@
           "optional": true
         },
         "terser": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite-tsconfig-paths": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-4.3.1.tgz",
-      "integrity": "sha512-cfgJwcGOsIxXOLU/nELPny2/LUD/lcf1IbfyeKTv2bsupVbTH/xpFtdQlBmIP1GEK2CjjLxYhFfB+QODFAx5aw==",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "globrex": "^0.1.2",
-        "tsconfck": "^3.0.1"
-      },
-      "peerDependencies": {
-        "vite": "*"
-      },
-      "peerDependenciesMeta": {
-        "vite": {
           "optional": true
         }
       }
@@ -14876,7 +14833,7 @@
       "version": "0.18.11",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.11.tgz",
       "integrity": "sha512-i8u6mQF0JKJUlGR3OdFLKldJQMMs8OqM9Cc3UCi9XXziJ9WERM5bfkHaEAy0YAvPRMgqSW55W7xYn84XtEFTtA==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@esbuild/android-arm": "0.18.11",
         "@esbuild/android-arm64": "0.18.11",
@@ -15496,11 +15453,6 @@
         "merge2": "^1.4.1",
         "slash": "^3.0.0"
       }
-    },
-    "globrex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
     },
     "gopd": {
       "version": "1.0.1",
@@ -17312,7 +17264,7 @@
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
       "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
-      "devOptional": true
+      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -17584,7 +17536,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "devOptional": true
+      "dev": true
     },
     "picomatch": {
       "version": "2.3.1",
@@ -17628,7 +17580,7 @@
       "version": "8.4.33",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
       "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
@@ -17924,7 +17876,7 @@
       "version": "3.26.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.26.2.tgz",
       "integrity": "sha512-6umBIGVz93er97pMgQO08LuH3m6PUb3jlDUUGFsNJB6VgTCUaDFpupf5JfU30529m/UKOgmiX+uY6Sx8cOYpLA==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
       }
@@ -18103,7 +18055,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "devOptional": true
+      "dev": true
     },
     "source-map-support": {
       "version": "0.5.13",
@@ -18530,12 +18482,6 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true
     },
-    "tsconfck": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.0.2.tgz",
-      "integrity": "sha512-6lWtFjwuhS3XI4HsX4Zg0izOI3FU/AI9EGVlPEUMDIhvLPMD4wkiof0WCoDgW7qY+Dy198g4d9miAqUHWHFH6Q==",
-      "requires": {}
-    },
     "tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
@@ -18566,7 +18512,7 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "devOptional": true
+      "dev": true
     },
     "ufo": {
       "version": "1.3.2",
@@ -18639,7 +18585,7 @@
       "version": "4.4.8",
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.8.tgz",
       "integrity": "sha512-LONawOUUjxQridNWGQlNizfKH89qPigK36XhMI7COMGztz8KNY0JHim7/xDd71CZwGT4HtSRgI7Hy+RlhG0Gvg==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "esbuild": "^0.18.10",
         "fsevents": "~2.3.2",
@@ -18978,16 +18924,6 @@
             "rollup": "^4.2.0"
           }
         }
-      }
-    },
-    "vite-tsconfig-paths": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-4.3.1.tgz",
-      "integrity": "sha512-cfgJwcGOsIxXOLU/nELPny2/LUD/lcf1IbfyeKTv2bsupVbTH/xpFtdQlBmIP1GEK2CjjLxYhFfB+QODFAx5aw==",
-      "requires": {
-        "debug": "^4.1.1",
-        "globrex": "^0.1.2",
-        "tsconfck": "^3.0.1"
       }
     },
     "vitefu": {

--- a/package.json
+++ b/package.json
@@ -63,8 +63,7 @@
     "@polkadot/types": "^10.11.2",
     "@polkadot/util": "^12.6.2",
     "jsdom": "^24.0.0",
-    "rxjs": "^7.8.1",
-    "vite-tsconfig-paths": "^4.3.1"
+    "rxjs": "^7.8.1"
   },
   "stackblitz": {
     "startCommand": "npm run test:ui"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "@polkadot/types": "^10.11.2",
     "@polkadot/util": "^12.6.2",
     "jsdom": "^24.0.0",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "vite-tsconfig-paths": "^4.3.1"
   },
   "stackblitz": {
     "startCommand": "npm run test:ui"

--- a/src/components/AddControlKey.svelte
+++ b/src/components/AddControlKey.svelte
@@ -127,7 +127,6 @@
     <span class="border-1 border-b border-divider" />
 
     <AddKeyRequirements />
-
     <TransactionStatus bind:showSelf={showTransactionStatus} statuses={txnStatuses} />
   </svelte:fragment>
 </Modal>

--- a/src/components/BecomeAProvider.svelte
+++ b/src/components/BecomeAProvider.svelte
@@ -7,8 +7,6 @@
   import CreateProvider from './CreateProvider.svelte';
   import EmailProviderRequest from './EmailProviderRequest.svelte';
   import { pageContent } from '$lib/stores/pageContentStore';
-  import { dotApi } from '$lib/stores';
-  import { createAndConnectToApi } from '$lib/polkadotApi';
 
   let newUser: Account | undefined;
 
@@ -17,20 +15,11 @@
     pageContent.login();
   };
 
-  async function updateApiAndUser() {
+  async function updateUser() {
     if (!newUser) {
       alert('Invalid form values');
       return;
     }
-
-    const endpoint = newUser.network?.endpoint?.origin;
-    if (!endpoint) {
-      alert('Error connecting to endpoint.');
-      return;
-    }
-
-    if ($dotApi.api?.isConnected) $dotApi.api?.disconnect();
-    await createAndConnectToApi(endpoint);
     $user = newUser;
   }
 </script>
@@ -49,9 +38,9 @@
         <EmailProviderRequest />
       {:else if newUser && newUser?.address !== ''}
         {#if newUser?.msaId === 0}
-          <CreateMsa beforeCreate={updateApiAndUser} />
+          <CreateMsa beforeCreate={updateUser} />
         {:else}
-          <CreateProvider beforeCreate={updateApiAndUser} />
+          <CreateProvider beforeCreate={updateUser} />
         {/if}
       {:else}
         <button on:click|preventDefault={cancelAction} class="btn-no-fill text-left">Cancel</button>

--- a/src/components/BecomeAProvider.svelte
+++ b/src/components/BecomeAProvider.svelte
@@ -26,7 +26,7 @@
 
 <div id="become-a-provider" class="content-block column w-single-block">
   <BlockSection title="Become a Provider">
-    <form class="column w-[350px]">
+    <form class="column w-[320px]">
       <SelectNetworkAndAccount
         bind:newUser
         accounts={$nonProviderAccountsStore}

--- a/src/components/BecomeAProvider.svelte
+++ b/src/components/BecomeAProvider.svelte
@@ -15,7 +15,7 @@
     pageContent.login();
   };
 
-  async function updateUser() {
+  function updateUser() {
     if (!newUser) {
       alert('Invalid form values');
       return;

--- a/src/components/Capacity.svelte
+++ b/src/components/Capacity.svelte
@@ -1,19 +1,18 @@
 <script lang="ts">
   import { dotApi, storeChainInfo } from '$lib/stores';
   import { user } from '$lib/stores/userStore';
-  import type { ApiPromise } from '@polkadot/api';
   import { getCapacityInfo, type CapacityDetails } from '$lib/polkadotApi';
   import { balanceToHuman } from '$lib/utils.js';
   import ListCard from './ListCard.svelte';
   import Stake from './Stake.svelte';
-  import { afterUpdate } from 'svelte';
 
   let capacityDetails: CapacityDetails;
-  afterUpdate(async () => {
-    if ($user?.msaId && $user?.msaId > 0) {
-      capacityDetails = await getCapacityInfo($dotApi.api as ApiPromise, $user.msaId);
+
+  $: {
+    if ($user?.msaId && $user.msaId !== 0 && $dotApi.api) {
+      getCapacityInfo($dotApi.api, $user.msaId).then((info) => (capacityDetails = info));
     }
-  });
+  }
 
   let showStakeToProvider = false;
   let capacityList: { label: string; value: string }[] = [];

--- a/src/components/ConnectionStatus.svelte
+++ b/src/components/ConnectionStatus.svelte
@@ -15,7 +15,7 @@
       {:else}
         <div class="w-1 bg-red-error h-1 rounded-full p-1" />
       {/if}
-      <p class="text-md uppercase">{$user.network?.name}</p>
+      <p id="connected-network" class="text-md uppercase">{$user.network?.name}</p>
     </div>
     <p class="text-md">
       {#if $user?.network}{$user.network.endpoint?.toString().replace(/\/$/, '')}{/if}

--- a/src/components/CreateMsa.svelte
+++ b/src/components/CreateMsa.svelte
@@ -39,11 +39,13 @@
 
   const doCreateMsa = async (_evt: Event) => {
     await beforeCreate();
+
     const endpoint: string | undefined = $user.network?.endpoint;
     if (!endpoint) {
       alert('Error connecting to endpoint.');
       return;
     }
+
     clearTxnStatuses();
     showTransactionStatus = true;
     const apiPromise = $dotApi.api as ApiPromise;

--- a/src/components/CreateMsa.svelte
+++ b/src/components/CreateMsa.svelte
@@ -39,13 +39,11 @@
 
   const doCreateMsa = async (_evt: Event) => {
     await beforeCreate();
-
-    const endpoint: string | undefined = $user.network?.endpoint?.origin;
+    const endpoint: string | undefined = $user.network?.endpoint;
     if (!endpoint) {
       alert('Error connecting to endpoint.');
       return;
     }
-
     clearTxnStatuses();
     showTransactionStatus = true;
     const apiPromise = $dotApi.api as ApiPromise;

--- a/src/components/CreateProvider.svelte
+++ b/src/components/CreateProvider.svelte
@@ -11,7 +11,6 @@
   import { getMsaInfo } from '$lib/polkadotApi';
   import type { MsaInfo } from '$lib/storeTypes';
   import { pageContent } from '$lib/stores/pageContentStore';
-  import { isLoggedIn } from '$lib/stores';
 
   export let beforeCreate: () => Promise<void>;
   export let txnStatuses: Array<string> = [];
@@ -25,7 +24,6 @@
       const msaInfo: MsaInfo = await getMsaInfo($dotApi.api!, $user.address);
       $user.providerName = providerNameToHuman(msaInfo.providerName);
       $user.isProvider = msaInfo.isProvider;
-      $isLoggedIn = true;
       pageContent.dashboard();
     }
   };
@@ -44,7 +42,7 @@
   const doCreateProvider = async (_evt: Event) => {
     await beforeCreate();
 
-    const endpointURI: string | undefined = $user.network?.endpoint?.origin;
+    const endpointURI: string | undefined = $user.network?.endpoint;
     if (!endpointURI) {
       alert('Error connecting to endpoint.');
       return;

--- a/src/components/Dashboard.svelte
+++ b/src/components/Dashboard.svelte
@@ -3,6 +3,29 @@
   import Provider from '$components/Provider.svelte';
   import DashboardHeader from '$components/DashboardHeader.svelte';
   import ChainStatus from '$components/ChainStatus.svelte';
+  import { fetchAccountsForNetwork } from '$lib/stores/accountsStore';
+  import { user } from '$lib/stores/userStore';
+  import type { ApiPromise } from '@polkadot/api';
+  import { dotApi } from '$lib/stores';
+  import { onMount } from 'svelte';
+  import type { web3Enable, web3Accounts } from '@polkadot/extension-dapp';
+
+  let thisWeb3Accounts: typeof web3Accounts;
+  let thisWeb3Enable: typeof web3Enable;
+
+  onMount(async () => {
+    const extension = await import('@polkadot/extension-dapp');
+    thisWeb3Accounts = extension.web3Accounts;
+    thisWeb3Enable = extension.web3Enable;
+  });
+
+  $: {
+    if ($user.network) {
+      fetchAccountsForNetwork($user.network, thisWeb3Enable, thisWeb3Accounts, $dotApi.api as ApiPromise).then(() =>
+        console.info('Accounts store updated.')
+      );
+    }
+  }
 </script>
 
 <div class="max-w-dashboard column w-full">

--- a/src/components/Dashboard.svelte
+++ b/src/components/Dashboard.svelte
@@ -28,7 +28,7 @@
   }
 </script>
 
-<div class="max-w-dashboard column w-full">
+<div class="max-w-dashboard column w-full" id="dashboard">
   <DashboardHeader />
 
   <ChainStatus />

--- a/src/components/LoginForm.svelte
+++ b/src/components/LoginForm.svelte
@@ -13,7 +13,7 @@
 
   async function connect() {
     if (!newUser) {
-      alert('Invalid form values.');
+      alert('Invalid form values');
       return;
     }
     $user = newUser;

--- a/src/components/LoginForm.svelte
+++ b/src/components/LoginForm.svelte
@@ -3,28 +3,19 @@
   import { user } from '$lib/stores/userStore';
   import Button from './Button.svelte';
   import SelectNetworkAndAccount from './SelectNetworkAndAccount.svelte';
-  import { createAndConnectToApi } from '$lib/polkadotApi';
 
   export let onConnect: () => void = () => {};
   export let onCancel: (() => void) | undefined = undefined;
 
-  let newUser: Account | undefined = $user;
+  let newUser: Account | undefined = $providerAccountsStore.get($user.address);
 
   $: canConnect = newUser?.network != null && $providerAccountsStore.size > 0 && newUser?.address !== '';
 
   async function connect() {
     if (!newUser) {
-      alert('Invalid form values');
+      alert('Invalid form values.');
       return;
     }
-
-    const endpoint = newUser.network?.endpoint?.toString();
-    if (!endpoint) {
-      alert('Error connecting to endpoint.');
-      return;
-    }
-
-    await createAndConnectToApi(endpoint);
     $user = newUser;
     onConnect();
   }

--- a/src/components/Nav.svelte
+++ b/src/components/Nav.svelte
@@ -15,7 +15,7 @@
     <NavItem href="/" isActive={url === '/'}>Home</NavItem>
     <NavItem href="/faq" isActive={url === '/faq'}>FAQ's</NavItem>
     {#if $isLoggedIn === true}
-      <NavItem href="/" onClick={logout}>Logout</NavItem>
+      <NavItem id="logout-button" href="/" onClick={logout}>Logout</NavItem>
     {:else}
       <NavItem />
     {/if}

--- a/src/components/Nav.svelte
+++ b/src/components/Nav.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { logout } from '$lib/stores/userStore';
+  import { logout } from '$lib/stores';
   import { isLoggedIn } from '$lib/stores';
   import iconLogo from '$lib/assets/icon-logo.png';
   import { onMount } from 'svelte';
@@ -14,8 +14,10 @@
   <div class="flex w-[100%] flex-col">
     <NavItem href="/" isActive={url === '/'}>Home</NavItem>
     <NavItem href="/faq" isActive={url === '/faq'}>FAQ's</NavItem>
-    {#if $isLoggedIn}
+    {#if $isLoggedIn === true}
       <NavItem href="/" onClick={logout}>Logout</NavItem>
+    {:else}
+      <NavItem />
     {/if}
   </div>
 </div>

--- a/src/components/NavItem.svelte
+++ b/src/components/NavItem.svelte
@@ -2,9 +2,11 @@
   export let href: string = '';
   export let isActive: boolean = false;
   export let onClick: () => void = () => {};
+  export let id: string = '';
 </script>
 
 <a
+  {id}
   {href}
   on:click|stopPropagation={onClick}
   class={` flex h-[100px] items-center justify-center text-sm font-bold ${

--- a/src/components/Provider.svelte
+++ b/src/components/Provider.svelte
@@ -5,17 +5,16 @@
   import { getBalances } from '$lib/polkadotApi';
   import type { AccountBalances } from '$lib/polkadotApi';
   import ListCard from './ListCard.svelte';
-  import { onMount } from 'svelte';
   import AddControlKey from './AddControlKey.svelte';
 
   let accountBalances: AccountBalances = { free: 0n, reserved: 0n, frozen: 0n };
   let isAddKeyOpen: boolean = false;
 
-  onMount(async () => {
+  $: {
     if ($dotApi.api) {
-      accountBalances = await getBalances($dotApi.api, $user.address);
+      getBalances($dotApi.api, $user.address).then((info) => (accountBalances = info));
     }
-  });
+  }
 
   let providerList: { label: string; value: string }[] = [];
   let errMsg: string = '';

--- a/src/components/ProviderLogin.svelte
+++ b/src/components/ProviderLogin.svelte
@@ -5,20 +5,11 @@
   import Button from '$components/Button.svelte';
   import HowToTransact from '$components/HowToTransact.svelte';
   import { pageContent } from '$lib/stores/pageContentStore';
-
-  async function onConnect() {
-    $isLoggedIn = true;
-    pageContent.dashboard();
-  }
-
-  function becomeProvider() {
-    pageContent.becomeProvider();
-  }
 </script>
 
 <div id="provider-login" class="content-block column w-single-block">
   <BlockSection title="Provider Login">
-    <LoginForm {onConnect} />
+    <LoginForm />
   </BlockSection>
 
   <BlockSection title="Not a Provider?">
@@ -26,7 +17,7 @@
       Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem
       aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
     </div>
-    <Button id="request-2b-provider-btn" title="Become a Provider" action={becomeProvider} />
+    <Button id="request-2b-provider-btn" title="Become a Provider" action={pageContent.becomeProvider} />
   </BlockSection>
 
   <HowToTransact additionalStyles="mt-24 text-xs gap-1" />

--- a/src/components/ProviderLogin.svelte
+++ b/src/components/ProviderLogin.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { isLoggedIn } from '$lib/stores';
   import BlockSection from '$components/BlockSection.svelte';
   import LoginForm from './LoginForm.svelte';
   import Button from '$components/Button.svelte';

--- a/src/components/SelectNetworkAndAccount.svelte
+++ b/src/components/SelectNetworkAndAccount.svelte
@@ -2,15 +2,14 @@
   import { onMount } from 'svelte';
   import { allNetworks, type NetworkInfo } from '$lib/stores/networksStore';
   import { createApi } from '$lib/polkadotApi';
-  import { Account, fetchAccountsForNetwork } from '$lib/stores/accountsStore';
-  import { user } from '$lib/stores/userStore';
+  import { Account, fetchAccountsForNetwork, type Accounts } from '$lib/stores/accountsStore';
   import type { ApiPromise } from '@polkadot/api';
   import type { web3Enable, web3Accounts } from '@polkadot/extension-dapp';
   import DropDownMenu from '$components/DropDownMenu.svelte';
   import { formatNetwork, formatAccount, isValidURL } from '$lib/utils';
 
   export let newUser: Account | undefined;
-  export let accounts: Map<string, Account>;
+  export let accounts: Accounts;
   export let accountSelectorTitle: string = 'Select an account';
   export let accountSelectorPlaceholder: string = 'Select an account';
   export let noAccountsFoundErrorMsg: string = 'No accounts found.';
@@ -24,6 +23,8 @@
   let customNetwork: string;
   let isCustomNetwork: boolean;
   let isLoading: boolean = false;
+
+  console.log('selectedNetwork', selectedNetwork);
 
   // Error messages
   let networkErrorMsg: string = '';
@@ -44,13 +45,13 @@
         networkErrorMsg = '';
         controlKeysErrorMsg = '';
         if (!network.endpoint) throw new Error('Undefined endpoint.');
-        const curApi = await createApi(network.endpoint?.origin);
+        const curApi = await createApi(network.endpoint);
         await fetchAccountsForNetwork(network, thisWeb3Enable, thisWeb3Accounts, curApi.api as ApiPromise);
         await curApi.api?.disconnect();
       } catch (e) {
         console.log(e);
         networkErrorMsg = `Could not connect to ${
-          network.endpoint?.origin || 'empty value'
+          network.endpoint || 'empty value'
         }. Please enter a valid and reachable Websocket URL.`;
         console.error(networkErrorMsg);
       }
@@ -78,8 +79,7 @@
   function customNetworkChanged(event: KeyboardEvent) {
     if (event.key === 'Enter') {
       if (isValidURL(customNetwork)) {
-        const url = new URL(customNetwork);
-        selectedNetwork!.endpoint = url;
+        selectedNetwork!.endpoint = customNetwork;
       }
     }
   }

--- a/src/components/SelectNetworkAndAccount.svelte
+++ b/src/components/SelectNetworkAndAccount.svelte
@@ -24,8 +24,6 @@
   let isCustomNetwork: boolean;
   let isLoading: boolean = false;
 
-  console.log('selectedNetwork', selectedNetwork);
-
   // Error messages
   let networkErrorMsg: string = '';
   let controlKeysErrorMsg: string = '';

--- a/src/components/Stake.svelte
+++ b/src/components/Stake.svelte
@@ -31,6 +31,10 @@
       </ol>
     </div>
 
+    {#if showTransactionStatus}
+      <span class="min-w-full border-b border-b-divider" />
+    {/if}
+
     <TransactionStatus bind:showSelf={showTransactionStatus} statuses={txnStatuses} />
   </svelte:fragment>
 </Modal>

--- a/src/components/StakeForm.svelte
+++ b/src/components/StakeForm.svelte
@@ -82,6 +82,7 @@
     }
     isLoading = false;
   };
+  console.log('allAccountsStore', $allAccountsStore);
 </script>
 
 <form class="column">

--- a/src/components/StakeForm.svelte
+++ b/src/components/StakeForm.svelte
@@ -100,7 +100,7 @@
     <input type="number" id="stakingInput" min="0" value="1" on:input={handleInput} />
   </div>
 
-  <div class="flex w-[350px] items-end justify-between">
+  <div class="flex w-[320px] items-end justify-between">
     <button on:click|preventDefault={stake} class="btn-primary" aria-label="Stake" disabled={isLoading}>Stake</button>
     <button class="btn-no-fill" on:click|preventDefault={close}>Cancel</button>
   </div>

--- a/src/components/StakeForm.svelte
+++ b/src/components/StakeForm.svelte
@@ -18,7 +18,7 @@
   export let providerId = 0;
   export let txnFinished: TxnFinishedCallback = (succeeded: boolean) => {};
 
-  let selectedAccount: Account = $user;
+  let selectedAccount: Account;
   let isLoading: boolean = false;
   let thisWeb3FromSource: typeof web3FromSource;
   let thisWeb3Enable: typeof web3Enable;
@@ -27,6 +27,7 @@
     const extension = await import('@polkadot/extension-dapp');
     thisWeb3FromSource = extension.web3FromSource;
     thisWeb3Enable = extension.web3Enable;
+    selectedAccount = $allAccountsStore.get($user.address) as Account;
   });
 
   $: stakeAmountInPlancks = BigInt.asUintN(64, stakeAmount) * BigInt.asUintN(64, DOLLARS);
@@ -82,7 +83,6 @@
     }
     isLoading = false;
   };
-  console.log('allAccountsStore', $allAccountsStore);
 </script>
 
 <form class="column">

--- a/src/components/TransactionStatus.svelte
+++ b/src/components/TransactionStatus.svelte
@@ -8,16 +8,12 @@
   };
 </script>
 
-<div class:hidden={!showSelf} id="transaction-status" class="column w-full">
-  <span class="border-1 border-b border-divider" />
-
-  <div>
-    <p class="label">Transaction Status</p>
-    <ul class="unordered-list break-words text-sm">
-      {#each statuses as status}
-        <li>{status}</li>
-      {/each}
-    </ul>
-    <button on:click|preventDefault={hideSelf} class="btn-no-fill mt-4">Dismiss Status</button>
-  </div>
+<div class:hidden={!showSelf} id="transaction-status" class="">
+  <p class="label">Transaction Status</p>
+  <ul class="unordered-list break-words text-sm">
+    {#each statuses as status}
+      <li>{status}</li>
+    {/each}
+  </ul>
+  <button on:click|preventDefault={hideSelf} class="btn-no-fill mt-4">Dismiss Status</button>
 </div>

--- a/src/lib/connections.ts
+++ b/src/lib/connections.ts
@@ -1,5 +1,4 @@
-// @ts-ignore
-import { ApiPromise } from '@polkadot/api/promise';
+import type { ApiPromise } from '@polkadot/api/promise';
 // @ts-ignore
 // import { SignerResult } from "@polkadot/types";
 import { isLocalhost, waitFor } from '$lib/utils';

--- a/src/lib/polkadotApi.ts
+++ b/src/lib/polkadotApi.ts
@@ -1,6 +1,4 @@
 import { ApiPromise, Keyring, WsProvider } from '@polkadot/api';
-import { getBlockNumber, getEpoch } from './connections';
-import { dotApi, storeChainInfo } from './stores';
 import { options } from '@frequency-chain/api-augment';
 
 import type { DotApi, MsaInfo } from '$lib/storeTypes';
@@ -9,20 +7,6 @@ import type { ChainProperties } from '@polkadot/types/interfaces';
 import type { Option, u64 } from '@polkadot/types';
 
 export type AccountMap = Record<string, KeyringPair>;
-
-async function updateChainInfo(api: ApiPromise) {
-  const chain = await api.rpc.system.properties();
-  const token = getToken(chain);
-  const blockNumber = (await getBlockNumber(api)) as bigint;
-  const epochNumber = await getEpoch(api);
-  storeChainInfo.set({ connected: true, blockNumber, epochNumber, token });
-}
-
-export async function createAndConnectToApi(networkEndpoint: string) {
-  const initializedDotApi = await createApi(networkEndpoint);
-  dotApi.set(initializedDotApi);
-  await updateChainInfo(initializedDotApi.api);
-}
 
 export async function createApi(networkEndpoint: string): Promise<DotApi> {
   const wsProvider = new WsProvider(networkEndpoint);

--- a/src/lib/polkadotApi.ts
+++ b/src/lib/polkadotApi.ts
@@ -50,9 +50,9 @@ export async function getBalances(apiPromise: ApiPromise, accountId: string): Pr
 }
 
 export async function getMsaInfo(apiPromise: ApiPromise, publicKey: string): Promise<MsaInfo> {
-  const received: u64 = (await apiPromise.query.msa.publicKeyToMsaId(publicKey)).unwrapOrDefault();
+  const received: u64 = (await apiPromise?.query.msa.publicKeyToMsaId(publicKey))?.unwrapOrDefault();
   const msaInfo: MsaInfo = { isProvider: false, msaId: 0, providerName: '' };
-  msaInfo.msaId = received.toNumber();
+  msaInfo.msaId = received?.toNumber();
   if (msaInfo.msaId > 0) {
     const providerRegistry: Option<any> = await apiPromise.query.msa.providerToRegistryEntry(msaInfo.msaId);
     if (providerRegistry.isSome) {

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -1,5 +1,5 @@
 import { writable } from 'svelte/store';
-import { ActionForms, defaultDotApi, type DotApi } from '$lib/storeTypes';
+import { defaultDotApi, type DotApi } from '$lib/storeTypes';
 import { storable } from './stores/storable';
 import { derived } from 'svelte/store';
 import { user } from './stores/userStore';
@@ -7,8 +7,6 @@ import { createApi } from './polkadotApi';
 import { pageContent } from './stores/pageContentStore';
 
 export const dotApi = writable<DotApi>(defaultDotApi);
-
-export const storeCurrentAction = writable(ActionForms.NoForm);
 
 export const isLoggedIn = storable<boolean>('isLoggedIn', false);
 

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -1,8 +1,55 @@
 import { writable } from 'svelte/store';
-import { defaultDotApi } from '$lib/storeTypes';
+import { defaultDotApi, type DotApi } from '$lib/storeTypes';
+import { storable } from './stores/storable';
+import { derived } from 'svelte/store';
+import { user } from './stores/userStore';
+import { createApi, getToken } from './polkadotApi';
+import { getBlockNumber, getEpoch } from './connections';
+import { pageContent } from './stores/pageContentStore';
 
-export const dotApi = writable(defaultDotApi);
+export const dotApi = writable<DotApi>(defaultDotApi);
 
-export const storeChainInfo = writable({ connected: false, blockNumber: 0n, epochNumber: 0n, token: '' });
+export const isLoggedIn = storable<boolean>('isLoggedIn', false);
 
-export const isLoggedIn = writable(false);
+export const logInPromise = derived([user], ([$user]) =>
+  (async () => {
+    let endpoint = $user?.network?.endpoint;
+    if (endpoint) {
+      dotApi.set(await createApi(endpoint));
+      isLoggedIn.set(true);
+      if ($user.isProvider) {
+        pageContent.dashboard();
+        //TODO: NEED TO ADD SOMETHING TO GET THE ACCOUNTS.
+        //CURRENTLY, WHEN YOU GO TO STEAK, THERE IS NO ACCOUNT OPTIONS
+        //WORKS IN CONNECT PROVIDER BECAUSE WE GET ACCOUNTS IN THE COMPONENT.
+      }
+    }
+  })()
+);
+
+export const logout = () => {
+  isLoggedIn.update((value) => (value = false));
+  user.set({ address: '', isProvider: false });
+  dotApi.set(defaultDotApi);
+  storeChainInfo.set({ connected: false, blockNumber: 0n, epochNumber: 0n, token: '' });
+  pageContent.login();
+};
+
+export const storeChainInfo = storable('storeChainInfo', {
+  connected: false,
+  blockNumber: 0n,
+  epochNumber: 0n,
+  token: '',
+});
+
+export const storeChainInfoPromise = derived([dotApi], ([$dotApi]) =>
+  (async () => {
+    const chain = await $dotApi?.api?.rpc.system.properties();
+    if ($dotApi?.api && chain) {
+      const token = getToken(chain);
+      const blockNumber = (await getBlockNumber($dotApi.api)) as bigint;
+      const epochNumber = await getEpoch($dotApi.api);
+      storeChainInfo.set({ connected: true, blockNumber, epochNumber, token });
+    }
+  })()
+);

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -3,8 +3,7 @@ import { ActionForms, defaultDotApi, type DotApi } from '$lib/storeTypes';
 import { storable } from './stores/storable';
 import { derived } from 'svelte/store';
 import { user } from './stores/userStore';
-import { createApi, getToken } from './polkadotApi';
-import { getBlockNumber, getEpoch } from './connections';
+import { createApi } from './polkadotApi';
 import { pageContent } from './stores/pageContentStore';
 
 export const dotApi = writable<DotApi>(defaultDotApi);
@@ -39,15 +38,3 @@ export const storeChainInfo = storable('storeChainInfo', {
   epochNumber: 0n,
   token: '',
 });
-
-export const storeChainInfoPromise = derived([dotApi], ([$dotApi]) =>
-  (async () => {
-    const chain = await $dotApi?.api?.rpc.system.properties();
-    if ($dotApi?.api && chain) {
-      const token = getToken(chain);
-      const blockNumber = (await getBlockNumber($dotApi.api)) as bigint;
-      const epochNumber = await getEpoch($dotApi.api);
-      storeChainInfo.set({ connected: true, blockNumber, epochNumber, token });
-    }
-  })()
-);

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -13,15 +13,11 @@ export const isLoggedIn = storable<boolean>('isLoggedIn', false);
 
 export const logInPromise = derived([user], ([$user]) =>
   (async () => {
-    let endpoint = $user?.network?.endpoint;
-    if (endpoint) {
-      dotApi.set(await createApi(endpoint));
+    if ($user?.network?.endpoint) {
+      dotApi.set(await createApi($user?.network?.endpoint));
       isLoggedIn.set(true);
       if ($user.isProvider) {
         pageContent.dashboard();
-        //TODO: NEED TO ADD SOMETHING TO GET THE ACCOUNTS.
-        //CURRENTLY, WHEN YOU GO TO STEAK, THERE IS NO ACCOUNT OPTIONS
-        //WORKS IN CONNECT PROVIDER BECAUSE WE GET ACCOUNTS IN THE COMPONENT.
       }
     }
   })()

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -1,5 +1,5 @@
 import { writable } from 'svelte/store';
-import { defaultDotApi, type DotApi } from '$lib/storeTypes';
+import { ActionForms, defaultDotApi, type DotApi } from '$lib/storeTypes';
 import { storable } from './stores/storable';
 import { derived } from 'svelte/store';
 import { user } from './stores/userStore';
@@ -8,6 +8,8 @@ import { getBlockNumber, getEpoch } from './connections';
 import { pageContent } from './stores/pageContentStore';
 
 export const dotApi = writable<DotApi>(defaultDotApi);
+
+export const storeCurrentAction = writable(ActionForms.NoForm);
 
 export const isLoggedIn = storable<boolean>('isLoggedIn', false);
 

--- a/src/lib/stores/accountsStore.ts
+++ b/src/lib/stores/accountsStore.ts
@@ -59,6 +59,7 @@ export async function fetchAccountsForNetwork(
         account.signingKey = keyRingPair;
         account.isProvider = msaInfo.isProvider;
         account.providerName = providerNameToHuman(msaInfo.providerName);
+        allAccounts.set(account.address, account);
         if (account.isProvider) {
           providerAccounts.set(account.address, account);
         } else {

--- a/src/lib/stores/networksStore.ts
+++ b/src/lib/stores/networksStore.ts
@@ -5,21 +5,21 @@ import { writable } from 'svelte/store';
  */
 export interface NetworkInfo {
   name: string;
-  endpoint?: URL;
+  endpoint?: string;
   genesisHash?: string;
 }
 
 export const allNetworks = writable<NetworkInfo[]>([
   {
     name: 'MAINNET',
-    endpoint: new URL('wss://1.rpc.frequency.xyz'),
+    endpoint: 'wss://1.rpc.frequency.xyz',
     genesisHash: '0x4a587bf17a404e3572747add7aab7bbe56e805a5479c6c436f07f36fcc8d3ae1',
   },
   {
     name: 'TESTNET',
-    endpoint: new URL('wss://rpc.rococo.frequency.xyz'),
+    endpoint: 'wss://rpc.rococo.frequency.xyz',
     genesisHash: '0x0c33dfffa907de5683ae21cc6b4af899b5c4de83f3794ed75b2dc74e1b088e72',
   },
-  { name: 'LOCALHOST', endpoint: new URL('ws://127.0.0.1:9944') },
+  { name: 'LOCALHOST', endpoint: 'ws://127.0.0.1:9944' },
   { name: 'CUSTOM' },
 ]);

--- a/src/lib/stores/pageContentStore.ts
+++ b/src/lib/stores/pageContentStore.ts
@@ -1,4 +1,4 @@
-import { writable } from 'svelte/store';
+import { storable } from './storable';
 
 export enum PageContent {
   Dashboard = 'dashboard',
@@ -7,7 +7,7 @@ export enum PageContent {
 }
 
 const createPageContentStore = () => {
-  const { subscribe, set } = writable(PageContent.Login);
+  const { subscribe, set } = storable(PageContent.Login);
 
   return {
     subscribe,

--- a/src/lib/stores/pageContentStore.ts
+++ b/src/lib/stores/pageContentStore.ts
@@ -7,7 +7,7 @@ export enum PageContent {
 }
 
 const createPageContentStore = () => {
-  const { subscribe, set } = storable(PageContent.Login);
+  const { subscribe, set } = storable('pageContent', PageContent.Login);
 
   return {
     subscribe,

--- a/src/lib/stores/storable.ts
+++ b/src/lib/stores/storable.ts
@@ -1,0 +1,35 @@
+import { writable } from 'svelte/store';
+import { browser } from '$app/environment';
+
+export function storable<T>(key: string, data?: T) {
+  const store = writable(data);
+  const { subscribe, set, update } = store;
+  const storage = browser ? window.localStorage : null;
+
+  if (storage) {
+    const storageValue = storage.getItem(key);
+    if (!!storageValue) {
+      set(storageValue ? JSON.parse(storageValue) : data);
+    }
+  }
+
+  function toJson(value: unknown) {
+    return JSON.stringify(value, (key, value) => (typeof value === 'bigint' ? value.toString() : value));
+  }
+
+  return {
+    subscribe,
+    set: (n: T) => {
+      storage && storage.setItem(key, toJson(n));
+      set(n);
+    },
+    update: (cb: (value: T) => T) => {
+      const new_cb = (old_value: T) => {
+        const new_value = cb(old_value);
+        storage && storage.setItem(key, toJson(new_value));
+        return new_value;
+      };
+      update(new_cb);
+    },
+  };
+}

--- a/src/lib/stores/storable.ts
+++ b/src/lib/stores/storable.ts
@@ -8,7 +8,7 @@ export function storable<T>(key: string, data?: T) {
 
   if (storage) {
     const storageValue = storage.getItem(key);
-    if (!!storageValue) {
+    if (storageValue) {
       set(storageValue ? JSON.parse(storageValue) : data);
     }
   }

--- a/src/lib/stores/storable.ts
+++ b/src/lib/stores/storable.ts
@@ -1,10 +1,10 @@
 import { writable } from 'svelte/store';
-import { browser } from '$app/environment';
+import { BROWSER } from 'esm-env';
 
 export function storable<T>(key: string, data?: T) {
   const store = writable(data);
   const { subscribe, set, update } = store;
-  const storage = browser ? window.localStorage : null;
+  const storage = BROWSER ? window.localStorage : null;
 
   if (storage) {
     const storageValue = storage.getItem(key);

--- a/src/lib/stores/userStore.ts
+++ b/src/lib/stores/userStore.ts
@@ -1,15 +1,4 @@
-import { writable } from 'svelte/store';
-import { Account } from './accountsStore';
-import { dotApi, isLoggedIn, storeChainInfo } from '../stores';
-import { defaultDotApi } from '../storeTypes';
-import { pageContent } from '../stores/pageContentStore';
+import type { Account } from '$lib/stores/accountsStore';
+import { storable } from './storable';
 
-export const user = writable<Account>(new Account());
-
-export const logout = () => {
-  user.set(new Account());
-  dotApi.set(defaultDotApi);
-  isLoggedIn.set(false);
-  storeChainInfo.set({ connected: false, blockNumber: 0n, epochNumber: 0n, token: '' });
-  pageContent.login();
-};
+export const user = storable<Account>('user', { address: '', isProvider: false });

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,11 +1,27 @@
-<script>
+<script lang="ts">
   import Header from '../components/Header.svelte';
   import Nav from '../components/Nav.svelte';
   import wave from '$lib/assets/bg-wave.png';
-  import { logInPromise, storeChainInfoPromise } from '$lib/stores';
+  import { logInPromise, dotApi, storeChainInfo } from '$lib/stores';
+  import { getToken } from '$lib/polkadotApi';
+  import { getBlockNumber, getEpoch } from '$lib/connections';
 
   $: $logInPromise;
-  $: $storeChainInfoPromise;
+
+  $: {
+    $dotApi?.api?.rpc.system.properties().then((chain) => {
+      if ($dotApi?.api && chain) {
+        const token = getToken(chain);
+        Promise.all([getBlockNumber($dotApi.api), getEpoch($dotApi.api)])
+          .then(([blockNumber, epochNumber]) => {
+            storeChainInfo.set({ connected: true, blockNumber, epochNumber, token });
+          })
+          .catch((error) => {
+            console.error(error);
+          });
+      }
+    });
+  }
 </script>
 
 <div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,6 +2,10 @@
   import Header from '../components/Header.svelte';
   import Nav from '../components/Nav.svelte';
   import wave from '$lib/assets/bg-wave.png';
+  import { logInPromise, storeChainInfoPromise } from '$lib/stores';
+
+  $: $logInPromise;
+  $: $storeChainInfoPromise;
 </script>
 
 <div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,7 +4,6 @@
   import ProviderLogin from '$components/ProviderLogin.svelte';
   import { pageContent, PageContent } from '$lib/stores/pageContentStore';
 
-  $pageContent = PageContent.Login;
 </script>
 
 {#if $pageContent === PageContent.Dashboard}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,6 +3,10 @@
   import BecomeAProvider from '$components/BecomeAProvider.svelte';
   import ProviderLogin from '$components/ProviderLogin.svelte';
   import { pageContent, PageContent } from '$lib/stores/pageContentStore';
+
+  $: {
+    console.log('pageConents', $pageContent);
+  }
 </script>
 
 {#if $pageContent === PageContent.Dashboard}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,7 +3,6 @@
   import BecomeAProvider from '$components/BecomeAProvider.svelte';
   import ProviderLogin from '$components/ProviderLogin.svelte';
   import { pageContent, PageContent } from '$lib/stores/pageContentStore';
-
 </script>
 
 {#if $pageContent === PageContent.Dashboard}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,10 +3,6 @@
   import BecomeAProvider from '$components/BecomeAProvider.svelte';
   import ProviderLogin from '$components/ProviderLogin.svelte';
   import { pageContent, PageContent } from '$lib/stores/pageContentStore';
-
-  $: {
-    console.log('pageConents', $pageContent);
-  }
 </script>
 
 {#if $pageContent === PageContent.Dashboard}

--- a/src/style/app.css
+++ b/src/style/app.css
@@ -92,7 +92,7 @@
   [type='text'],
   [type='number'],
   select {
-    @apply h-[30px] w-[350px] overflow-ellipsis rounded-md border-none py-0 pl-2 text-sm text-black outline-none disabled:text-disabled disabled:opacity-85;
+    @apply h-[30px] w-[320px] overflow-ellipsis rounded-md border-none py-0 pl-2 text-sm text-black outline-none disabled:text-disabled disabled:opacity-85;
   }
 
   select {

--- a/test/e2e/page.test.ts
+++ b/test/e2e/page.test.ts
@@ -36,7 +36,7 @@ describe('End to End Tests', () => {
     });
 
     const btn = container.querySelector('button#connect-button');
-    await fireEvent.click(btn);
+    if (btn) await fireEvent.click(btn);
 
     // const connectionStatusValue = container.querySelector('#connection-status-value');
     // await waitFor(() => {

--- a/test/e2e/page.test.ts
+++ b/test/e2e/page.test.ts
@@ -22,10 +22,22 @@ describe('End to End Tests', () => {
 
   test('connect to localhost', async () => {
     const { container, getByLabelText } = render(Page);
+    // Is logged in
     const statusBar = container.querySelector('#chain-status');
     expect(statusBar).toBeDefined();
-    // Get the select box
-    const select = getByLabelText('Select a Network');
+
+    // Logout
+    const logoutBtn = container.querySelector('#logout-button');
+    expect(logoutBtn).toBeDefined();
+
+    logoutBtn && fireEvent.click(logoutBtn);
+
+    // Get the select box to log back in
+    const select = await getByLabelText('Select a Network');
+
+    await waitFor(() => {
+      expect(select).toHaveTextContent('LOCALHOST: ws://127.0.0.1:9944');
+    });
 
     // Change the select box value
     await fireEvent.change(select, { target: { value: 'LOCALHOST: ws://127.0.0.1:9944' } });

--- a/test/e2e/page.test.ts
+++ b/test/e2e/page.test.ts
@@ -1,6 +1,8 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import '@testing-library/jest-dom';
 import Page from '$routes/+page.svelte';
+import { user } from '../../src/lib/stores/userStore';
+import { pageContent } from '../../src/lib/stores/pageContentStore';
 
 // global.alert = () => {};
 // vitest mocking
@@ -16,31 +18,43 @@ const getByTextContent = (text) => {
   });
 };
 
+describe('displays correct component', () => {
+  it('renders Dashboard component when $pageContent is PageContent.Dashboard', async () => {
+    pageContent.dashboard();
+    const { container } = render(Page);
+    expect(container.querySelector('#dashboard') as HTMLElement).toBeInTheDocument();
+  });
+
+  it('renders ProviderLogin component when $pageContent is PageContent.Login', async () => {
+    pageContent.login();
+    const { container } = render(Page);
+    expect(container.querySelector('#provider-login') as HTMLElement).toBeInTheDocument();
+  });
+
+  it('renders BecomeAProvider component when $pageContent is PageContent.BecomeProvider', async () => {
+    pageContent.becomeProvider();
+    const { container } = render(Page);
+    expect(container.querySelector('#become-a-provider') as HTMLElement).toBeInTheDocument();
+  });
+});
+
 describe('End to End Tests', () => {
   // TODO: @testing-library/svelte claims to add this automatically but it doesn't work without explicit afterEach
   afterEach(() => cleanup());
 
-  test('connect to localhost', async () => {
-    const { container, getByLabelText } = render(Page);
-    // Is logged in
-    const statusBar = container.querySelector('#chain-status');
-    expect(statusBar).toBeDefined();
+  test('connect to localhost from login', async () => {
+    pageContent.login();
 
-    // Logout
-    const logoutBtn = container.querySelector('#logout-button');
-    expect(logoutBtn).toBeDefined();
-
-    logoutBtn && fireEvent.click(logoutBtn);
+    const { container, getByText } = render(Page);
+    expect(getByText('Provider Login')).toBeInTheDocument();
+    expect(getByText('Select a Network')).toBeInTheDocument();
 
     // Get the select box to log back in
-    const select = await getByLabelText('Select a Network');
-
-    await waitFor(() => {
-      expect(select).toHaveTextContent('LOCALHOST: ws://127.0.0.1:9944');
-    });
+    const select = container.querySelector('#network');
+    expect(select).not.toBeNull();
 
     // Change the select box value
-    await fireEvent.change(select, { target: { value: 'LOCALHOST: ws://127.0.0.1:9944' } });
+    await fireEvent.change(select!, { target: { value: 'LOCALHOST: ws://127.0.0.1:9944' } });
 
     // Be sure to wait for all the promises to resolve before checking the result
     await waitFor(() => {
@@ -50,9 +64,20 @@ describe('End to End Tests', () => {
     const btn = container.querySelector('button#connect-button');
     if (btn) await fireEvent.click(btn);
 
-    // const connectionStatusValue = container.querySelector('#connection-status-value');
-    // await waitFor(() => {
-    //   expect(connectionStatusValue).toHaveTextContent('Connected');
-    // });
+    waitFor(() => {
+      expect(container.querySelector('#dashboard') as HTMLElement).toBeInTheDocument();
+      const connectedNetwork = container.querySelector('#connected-network');
+      expect(connectedNetwork).toEqual('LOCALHOST');
+    });
+  });
+
+  test('values persist on reload', async () => {
+    const { container } = render(Page);
+
+    waitFor(() => {
+      expect(container.querySelector('#dashboard') as HTMLElement).toBeInTheDocument();
+      const connectedNetwork = container.querySelector('#connected-network');
+      expect(connectedNetwork).toEqual('LOCALHOST');
+    });
   });
 });

--- a/test/unit-and-integration/capacity.test.ts
+++ b/test/unit-and-integration/capacity.test.ts
@@ -5,7 +5,6 @@ import Capacity from '$components/Capacity.svelte';
 import { user } from '../../src/lib/stores/userStore';
 import { ChainInfo } from '../../src/lib/storeTypes';
 import { vi } from 'vitest';
-import { type ChainInfo } from '../../src/lib/storeTypes';
 
 const mocks = vi.hoisted(() => {
   class TestCodec {

--- a/test/unit-and-integration/capacity.test.ts
+++ b/test/unit-and-integration/capacity.test.ts
@@ -78,7 +78,7 @@ const mocks = vi.hoisted(() => {
     tx: { msa: { addPublicKeyToMsa: vi.fn().mockResolvedValue(undefined) } },
   };
 
-  const mockApiPromise = vi.fn();
+  const mockApiPromise: any = vi.fn();
   mockApiPromise.create = vi.fn().mockResolvedValue(resolvedCurrentEpochChain);
 
   const mockWeb3FromSource = vi.fn();

--- a/test/unit-and-integration/connections.test.ts
+++ b/test/unit-and-integration/connections.test.ts
@@ -11,7 +11,6 @@ import { Keyring } from '@polkadot/keyring';
 import { stringToU8a } from '@polkadot/util';
 import { SignerPayloadJSON, SignerPayloadRaw, SignerResult } from '@polkadot/types/types';
 import { vi } from 'vitest';
-import { waitReady } from '@polkadot/wasm-crypto';
 
 const mocks = vi.hoisted(() => {
   // this has to be inside here because otherwise the error will be

--- a/test/unit-and-integration/connections.test.ts
+++ b/test/unit-and-integration/connections.test.ts
@@ -10,6 +10,8 @@ import { ApiPromise } from '@polkadot/api';
 import { Keyring } from '@polkadot/keyring';
 import { stringToU8a } from '@polkadot/util';
 import { SignerPayloadJSON, SignerPayloadRaw, SignerResult } from '@polkadot/types/types';
+import { vi } from 'vitest';
+import { waitReady } from '@polkadot/wasm-crypto';
 
 const mocks = vi.hoisted(() => {
   // this has to be inside here because otherwise the error will be
@@ -47,7 +49,7 @@ const mocks = vi.hoisted(() => {
     }
   }
 
-  const mockApiPromise = vi.fn();
+  const mockApiPromise: any = vi.fn();
   const epochNumber = new TestCodec(101n);
   const mockCreatedType = new TestDetectCodec('hello world');
   const blockData = {

--- a/test/unit-and-integration/connections.test.ts
+++ b/test/unit-and-integration/connections.test.ts
@@ -11,6 +11,9 @@ import { Keyring } from '@polkadot/keyring';
 import { stringToU8a } from '@polkadot/util';
 import { SignerPayloadJSON, SignerPayloadRaw, SignerResult } from '@polkadot/types/types';
 import { vi } from 'vitest';
+import { waitReady } from '@polkadot/wasm-crypto';
+
+await waitReady();
 
 const mocks = vi.hoisted(() => {
   // this has to be inside here because otherwise the error will be

--- a/test/unit-and-integration/createMsa.test.ts
+++ b/test/unit-and-integration/createMsa.test.ts
@@ -1,7 +1,7 @@
 import { dotApi, storeChainInfo } from '../../src/lib/stores';
 import '@testing-library/jest-dom';
 import CreateMsa from '../../src/components/CreateMsa.svelte';
-
+import { vi } from 'vitest';
 import { fireEvent, render, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 

--- a/test/unit-and-integration/createProvider.test.ts
+++ b/test/unit-and-integration/createProvider.test.ts
@@ -1,7 +1,7 @@
 import { dotApi, storeChainInfo } from '../../src/lib/stores';
 import '@testing-library/jest-dom';
 import CreateProvider from '../../src/components/CreateProvider.svelte';
-
+import { vi } from 'vitest';
 import { fireEvent, render, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 

--- a/test/unit-and-integration/provider.test.ts
+++ b/test/unit-and-integration/provider.test.ts
@@ -7,6 +7,8 @@ import { ActionForms } from '../../src/lib/storeTypes';
 import { getByTextContent } from '../helpers';
 import { KeyringPair } from '@polkadot/keyring/types';
 import Keyring from '@polkadot/keyring';
+import { vi } from 'vitest';
+import { waitReady } from '@polkadot/wasm-crypto';
 
 const mocks = vi.hoisted(() => {
   class TestCodec {
@@ -59,7 +61,8 @@ const mocks = vi.hoisted(() => {
     },
   };
 
-  const mockApiPromise = vi.fn();
+  waitReady();
+  const mockApiPromise: any = vi.fn();
   mockApiPromise.create = vi.fn().mockResolvedValue(resolvedApi);
 
   const mockWeb3FromSource = vi.fn();

--- a/test/unit-and-integration/provider.test.ts
+++ b/test/unit-and-integration/provider.test.ts
@@ -6,6 +6,7 @@ import Provider from '$components/Provider.svelte';
 import { getByTextContent } from '../helpers';
 import { KeyringPair } from '@polkadot/keyring/types';
 import Keyring from '@polkadot/keyring';
+import { vi } from 'vitest';
 
 const mocks = vi.hoisted(() => {
   class TestCodec {
@@ -58,7 +59,7 @@ const mocks = vi.hoisted(() => {
     },
   };
 
-  const mockApiPromise = vi.fn();
+  const mockApiPromise: any = vi.fn();
   mockApiPromise.create = vi.fn().mockResolvedValue(resolvedApi);
 
   const mockWeb3FromSource = vi.fn();

--- a/test/unit-and-integration/provider.test.ts
+++ b/test/unit-and-integration/provider.test.ts
@@ -10,6 +10,8 @@ import Keyring from '@polkadot/keyring';
 import { vi } from 'vitest';
 import { waitReady } from '@polkadot/wasm-crypto';
 
+await waitReady();
+
 const mocks = vi.hoisted(() => {
   class TestCodec {
     value: number;
@@ -61,7 +63,6 @@ const mocks = vi.hoisted(() => {
     },
   };
 
-  waitReady();
   const mockApiPromise: any = vi.fn();
   mockApiPromise.create = vi.fn().mockResolvedValue(resolvedApi);
 

--- a/test/unit-and-integration/provider.test.ts
+++ b/test/unit-and-integration/provider.test.ts
@@ -1,9 +1,8 @@
 import { cleanup, render } from '@testing-library/svelte';
 import '@testing-library/jest-dom';
-import { dotApi, storeCurrentAction, storeChainInfo } from '../../src/lib/stores';
+import { dotApi, storeChainInfo } from '../../src/lib/stores';
 import { user } from '../../src/lib/stores/userStore';
 import Provider from '$components/Provider.svelte';
-import { ActionForms } from '../../src/lib/storeTypes';
 import { getByTextContent } from '../helpers';
 import { KeyringPair } from '@polkadot/keyring/types';
 import Keyring from '@polkadot/keyring';
@@ -79,7 +78,6 @@ vi.mock('@polkadot/api', async () => {
 
 describe('Provider.svelte', () => {
   beforeEach(() => {
-    storeCurrentAction.set(ActionForms.NoForm);
     user.set({ address: '', isProvider: false, msaId: 0, providerName: '' });
   });
   afterEach(() => cleanup());

--- a/test/unit-and-integration/provider.test.ts
+++ b/test/unit-and-integration/provider.test.ts
@@ -1,12 +1,12 @@
 import { cleanup, render } from '@testing-library/svelte';
 import '@testing-library/jest-dom';
-import { dotApi, storeChainInfo } from '../../src/lib/stores';
+import { dotApi, storeCurrentAction, storeChainInfo } from '../../src/lib/stores';
 import { user } from '../../src/lib/stores/userStore';
 import Provider from '$components/Provider.svelte';
+import { ActionForms } from '../../src/lib/storeTypes';
 import { getByTextContent } from '../helpers';
 import { KeyringPair } from '@polkadot/keyring/types';
 import Keyring from '@polkadot/keyring';
-import { vi } from 'vitest';
 
 const mocks = vi.hoisted(() => {
   class TestCodec {
@@ -59,7 +59,7 @@ const mocks = vi.hoisted(() => {
     },
   };
 
-  const mockApiPromise: any = vi.fn();
+  const mockApiPromise = vi.fn();
   mockApiPromise.create = vi.fn().mockResolvedValue(resolvedApi);
 
   const mockWeb3FromSource = vi.fn();
@@ -75,6 +75,7 @@ vi.mock('@polkadot/api', async () => {
 
 describe('Provider.svelte', () => {
   beforeEach(() => {
+    storeCurrentAction.set(ActionForms.NoForm);
     user.set({ address: '', isProvider: false, msaId: 0, providerName: '' });
   });
   afterEach(() => cleanup());

--- a/test/unit-and-integration/stake.test.ts
+++ b/test/unit-and-integration/stake.test.ts
@@ -6,6 +6,7 @@ import { user } from '../../src/lib/stores/userStore';
 import { KeyringPair } from '@polkadot/keyring/types';
 import Keyring from '@polkadot/keyring';
 import { vi } from 'vitest';
+import { waitReady } from '@polkadot/wasm-crypto';
 
 const mocks = vi.hoisted(() => {
   const resolvedApi = {
@@ -27,6 +28,10 @@ vi.mock('@polkadot/api', async () => {
 });
 
 describe('Stake.svelte Unit Tests', () => {
+  beforeAll(async () => {
+    await waitReady(); // Ensure WASM interface is ready before running tests
+  });
+
   beforeEach(() => {
     const keyring = new Keyring({ type: 'sr25519' });
     const keyRingPair: KeyringPair = { ...keyring.addFromUri('//Alice'), ...{ meta: { name: '//Alice' } } };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,14 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
-import { resolve } from 'path'
+import { resolve } from 'path';
 
 export default defineConfig({
-	plugins: [sveltekit()],
-	resolve: {
-		alias: {
-			$lib: resolve(__dirname, 'src/lib'),
-			$components: resolve(__dirname, 'src/components'),
-			$routes: resolve(__dirname, 'src/routes'),
-		},
-	}
+  plugins: [sveltekit()],
+  resolve: {
+    alias: {
+      $lib: resolve(__dirname, 'src/lib'),
+      $components: resolve(__dirname, 'src/components'),
+      $routes: resolve(__dirname, 'src/routes'),
+    },
+  },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,12 +1,10 @@
-import { defineConfig } from 'vitest/config'
-import { svelte } from '@sveltejs/vite-plugin-svelte'
-import { resolve } from 'path'
+import { defineConfig } from 'vitest/config';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { resolve } from 'path';
 
 // Why do the alias not work in vite.config.ts?
 export default defineConfig({
-  plugins: [
-    svelte({ hot: !process.env.VITEST }),
-  ],
+  plugins: [svelte({ hot: !process.env.VITEST })],
   resolve: {
     alias: {
       $lib: resolve(__dirname, 'src/lib'),
@@ -20,6 +18,6 @@ export default defineConfig({
     },
     environment: 'jsdom',
     globals: true,
-    reporters: "basic",
+    reporters: 'basic',
   },
-})
+});


### PR DESCRIPTION
closes #149 

## Changes Made:
- Added `storable` file that reads and writes from local storage to our desired stores.
- If the user has a stored network, connect to API using that network on load.
  - Because of this, we don't have to worry about connect to the API in any of the components, so I removed that code from `BecomeAProvider` and `LoginForm`.
  -   We could also simplify our functions in `polkadotApi.ts` to only use createApi().
- Made the state more reactive where possible for now.
- If viewing dashboard and the user has a stored network, fetchAccountsForNetwork, setting the accounts store reactivly.
- Swap out `afterUpdate()` or `onMount()` for `$:{}` where applicable so we can subscribe and update when changes happen, not only on load or infinite times with after update.
- Converted type URL to type string so that they could be parsed without problems when stored in local storage.
- Updated dropdowns to use .get() when setting the initial value so that it will be selected or display the placeholder (was blank).
- added some ids for testing
- updated e2e test.

## How to test
1. Login Flow:
- Login
- See expected dashboard
- Refresh and still see expected dashboard
- Click on logout button and be taken to login screen.
- Refresh, should still be logged out.
2. Become Provider Flow:
- Click on become a provider button
- Go to become provider page.
- Flow works as expected
- logged in and taken to dashboard on success
- Refresh and still see expected dashboard
3. Switch provider modal should function as expected.
4. Add key modal should function as expected.
5. Stake to provider should function as expected.
6. Logout should function as expected
7. Navigating to and from FAQ should not clear the data.