### PR TITLE
Support Paseo and account store cleanup

### DIFF
--- a/scripts/run_e2e_tests.sh
+++ b/scripts/run_e2e_tests.sh
@@ -53,6 +53,18 @@ case "${CHAIN}" in
             LOCAL_NODE_BLOCK_SEALING="manual"
         fi
     ;;
+    "paseo_local")
+        PROVIDER_URL="ws://127.0.0.1:9944"
+        NPM_RUN_COMMAND="test:relay"
+        CHAIN_ENVIRONMENT="paseo-local"
+    ;;
+    "paseo_testnet")
+        PROVIDER_URL="wss://0.rpc.testnet.amplica.io"
+        NPM_RUN_COMMAND="test:relay"
+        CHAIN_ENVIRONMENT="paseo-testnet"
+
+        read -p "Enter the seed phrase for the Frequency Rococo account funding source: " FUNDING_ACCOUNT_SEED_PHRASE
+    ;;
     "rococo_local")
         PROVIDER_URL="ws://127.0.0.1:9944"
         NPM_RUN_COMMAND="test:relay"
@@ -64,7 +76,6 @@ case "${CHAIN}" in
         CHAIN_ENVIRONMENT="rococo-testnet"
 
         read -p "Enter the seed phrase for the Frequency Rococo account funding source: " FUNDING_ACCOUNT_SEED_PHRASE
-
     ;;
 esac
 
@@ -73,7 +84,16 @@ then
     echo "Frequency is not running."
     echo "The intended use case of running integration tests with a chain environment"
     echo "of \"rococo-local\" is to run the tests against a locally running Frequency"
-    echo "chain with locally running Polkadot relay nodes."
+    echo "chain with locally running Rococo relay nodes."
+    exit 1
+fi
+
+if [ "${CHAIN_ENVIRONMENT}" = "paseo-local" ]
+then
+    echo "Frequency is not running."
+    echo "The intended use case of running integration tests with a chain environment"
+    echo "of \"paseo-local\" is to run the tests against a locally running Frequency"
+    echo "chain with locally running Paseo relay nodes."
     exit 1
 fi
 
@@ -82,7 +102,7 @@ case ${LOCAL_NODE_BLOCK_SEALING} in
     "instant") \
         docker run --rm -p 9944:9944 -p 30333:30333 --platform=linux/amd64 \
         --name vitest-node --detach \
-        frequencychain/instant-seal-node:latest &
+        frequencychain/standalone-node:latest &
     ;;
     "manual") ${RUNDIR}/init.sh start-frequency-manual >& frequency.log &
     ;;

--- a/src/components/Capacity.svelte
+++ b/src/components/Capacity.svelte
@@ -19,7 +19,7 @@
   let errMsg: string = '';
 
   $: {
-    if (!$user.injectedAccount) {
+    if (!$user.injectedAccount && !$user.keyringPair) {
       errMsg = 'No transaction signing address selected';
     } else if (!$user.msaId) {
       errMsg = 'No MSA ID.  Please create one.';

--- a/src/components/Capacity.svelte
+++ b/src/components/Capacity.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { dotApi, storeChainInfo } from '$lib/stores';
   import { user } from '$lib/stores/userStore';
+  import { activityLog } from '$lib/stores/activityLogStore';
   import { getCapacityInfo, type CapacityDetails } from '$lib/polkadotApi';
   import { balanceToHuman } from '$lib/utils.js';
   import ListCard from './ListCard.svelte';
@@ -9,6 +10,9 @@
   let capacityDetails: CapacityDetails;
 
   $: {
+    // Easy way to tag a subscription onto this action.
+    // This way we update the capacity information when the log updates
+    const _triggerReloadOnLogUpdate = $activityLog;
     if ($user?.msaId && $user.msaId !== 0 && $dotApi.api) {
       getCapacityInfo($dotApi.api, $user.msaId).then((info) => (capacityDetails = info));
     }

--- a/src/components/HowToTransact.svelte
+++ b/src/components/HowToTransact.svelte
@@ -10,10 +10,16 @@
   <p>To do that:</p>
   <ol class="ordered-list">
     <li>
-      <a href="https://faucet.rococo.frequency.xyz/" target="_blank" rel="noopener noreferrer" class="underline">
-        Get XRQCY tokens for Frequency Testnet (Rococo)
-      </a>
-      and follow the instructions using your desired wallet address to get XRQCY tokens.
+      Get XRQCY tokens for the <a
+        href="https://faucet.paseo.frequency.xyz/"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="underline">Frequency Testnet (Paseo)</a
+      >
+      or
+      <a href="https://faucet.rococo.frequency.xyz/" target="_blank" rel="noopener noreferrer" class="underline"
+        >Frequency Testnet (Rococo)</a
+      > and follow the instructions using your desired wallet address to get XRQCY tokens.
     </li>
     <li>
       Once that succeeds, verify the tokens have made it to your wallet by selecting or re-selecting the address above.
@@ -27,7 +33,7 @@
         rel="noopener noreferrer"
         class="underline"
       >
-        Rococo Accounts page via the Polkadot UI.
+        Accounts page for the correct network via the Polkadot UI.
       </a>
       .
     </li>

--- a/src/lib/connections.ts
+++ b/src/lib/connections.ts
@@ -1,7 +1,4 @@
 import type { ApiPromise } from '@polkadot/api/promise';
-// @ts-ignore
-// import { SignerResult } from "@polkadot/types";
-import { waitFor } from '$lib/utils';
 
 import type { KeyringPair } from '@polkadot/keyring/types';
 import type { InjectedExtension } from '@polkadot/extension-inject/types';

--- a/src/lib/stores/accountsStore.ts
+++ b/src/lib/stores/accountsStore.ts
@@ -1,4 +1,4 @@
-import { writable } from 'svelte/store';
+import { derived, writable, type Readable } from 'svelte/store';
 import { Keyring, type ApiPromise } from '@polkadot/api';
 import type { web3Enable, web3Accounts } from '@polkadot/extension-dapp';
 import { getMsaInfo } from '$lib/polkadotApi';
@@ -19,6 +19,7 @@ export class Account {
   msaId?: number;
   isProvider: boolean = false;
   providerName?: string;
+  display?: string;
 
   constructor() {
     this.address = '';
@@ -27,10 +28,25 @@ export class Account {
 
 export type Accounts = Map<SS58Address, Readonly<Account>>;
 
-export const providerAccountsStore = writable<Accounts>(new Map<SS58Address, Readonly<Account>>());
-export const nonProviderAccountsStore = writable<Accounts>(new Map<SS58Address, Readonly<Account>>());
-export const unusedKeyAccountsStore = writable<Accounts>(new Map<SS58Address, Readonly<Account>>());
+// Helper functions to filter all accounts to just the accounts for that store
+const isProvider = ([_key, account]: [string, Account]) => account.isProvider;
+const isNotProviderMsa = ([_key, account]: [string, Account]) => !account.isProvider;
+const isUnused = ([_key, account]: [string, Account]) => !account.isProvider && !account.msaId;
+
+// Stores all accounts
 export const allAccountsStore = writable<Accounts>(new Map<SS58Address, Readonly<Account>>());
+// Filtered down to just provider accounts
+export const providerAccountsStore = derived<Readable<Accounts>, Accounts>(allAccountsStore, (all, setFn) => {
+  setFn(new Map([...all.entries()].filter(isProvider)));
+});
+// These accounts don't even have an MSA
+export const unusedKeyAccountsStore = derived<Readable<Accounts>, Accounts>(allAccountsStore, (all, setFn) => {
+  setFn(new Map([...all.entries()].filter(isUnused)));
+});
+// These accounts have an MSA, but are not a provider
+export const nonProviderAccountsStore = derived<Readable<Accounts>, Accounts>(allAccountsStore, (all, setFn) => {
+  setFn(new Map([...all.entries()].filter(isNotProviderMsa)));
+});
 
 export async function fetchAccountsForNetwork(
   selectedNetwork: NetworkInfo,
@@ -40,9 +56,6 @@ export async function fetchAccountsForNetwork(
 ): Promise<void> {
   console.log('fetchAccountsForNetwork() - ', selectedNetwork);
 
-  const providerAccounts: Accounts = new Map<SS58Address, Account>();
-  const nonProviderAccounts: Accounts = new Map<SS58Address, Account>();
-  const unusedKeyAccounts: Accounts = new Map<SS58Address, Account>();
   const allAccounts: Accounts = new Map<SS58Address, Account>();
 
   // If the network is localhost, add the default test accounts for the chain
@@ -60,56 +73,42 @@ export async function fetchAccountsForNetwork(
         account.keyringPair = keyRingPair;
         account.isProvider = msaInfo.isProvider;
         account.providerName = providerNameToHuman(msaInfo.providerName);
+        account.display = accountName;
         allAccounts.set(account.address, account);
-        if (account.isProvider) {
-          providerAccounts.set(account.address, account);
-        } else {
-          if (account.msaId === 0) {
-            unusedKeyAccounts.set(account.address, account);
-          }
-          nonProviderAccounts.set(account.address, account);
-        }
       })
     );
   }
-  // Check if the Polkadot{.js} wallet extension is installed.
-  if (isFunction(thisWeb3Accounts) && isFunction(thisWeb3Enable)) {
-    const extensions = await thisWeb3Enable('Frequency parachain provider dashboard');
-    if (!extensions || !extensions.length) {
-      alert('Polkadot{.js} extension not found; please install it first.');
-      throw new Error('Polkadot{.js} extension not found; please install it first.');
+  try {
+    // Check if the Polkadot{.js} wallet extension is installed.
+    if (isFunction(thisWeb3Accounts) && isFunction(thisWeb3Enable)) {
+      const extensions = await thisWeb3Enable('Frequency parachain provider dashboard');
+      if (!extensions || !extensions.length) {
+        alert('Polkadot{.js} extension not found; please install it first.');
+        throw new Error('Polkadot{.js} extension not found; please install it first.');
+      }
+
+      // If so, add the wallet accounts for the selected network (chain)
+      const walletAccounts = await thisWeb3Accounts();
+      await Promise.all(
+        walletAccounts.map(async (walletAccount: InjectedAccountWithMeta) => {
+          // include only the accounts allowed for this chain
+          if (!walletAccount.meta.genesisHash || selectedNetwork.genesisHash === walletAccount.meta.genesisHash) {
+            const account = new Account();
+            account.network = selectedNetwork;
+            account.address = walletAccount.address;
+            account.injectedAccount = walletAccount;
+            const msaInfo: MsaInfo = await getMsaInfo(apiPromise, account.address);
+            account.msaId = msaInfo.msaId;
+            account.isProvider = msaInfo.isProvider;
+            account.providerName = providerNameToHuman(msaInfo.providerName);
+            account.display = walletAccount.meta.name;
+            allAccounts.set(account.address, account);
+          }
+        })
+      );
     }
-
-    // If so, add the wallet accounts for the selected network (chain)
-    const walletAccounts = await thisWeb3Accounts();
-    await Promise.all(
-      walletAccounts.map(async (walletAccount: InjectedAccountWithMeta) => {
-        // include only the accounts allowed for this chain
-        if (!walletAccount.meta.genesisHash || selectedNetwork.genesisHash === walletAccount.meta.genesisHash) {
-          const account = new Account();
-          account.network = selectedNetwork;
-          account.address = walletAccount.address;
-          account.injectedAccount = walletAccount;
-          const msaInfo: MsaInfo = await getMsaInfo(apiPromise, account.address);
-          account.msaId = msaInfo.msaId;
-          account.isProvider = msaInfo.isProvider;
-          account.providerName = providerNameToHuman(msaInfo.providerName);
-          allAccounts.set(account.address, account);
-          if (account.isProvider) {
-            providerAccounts.set(account.address, account);
-          } else {
-            if (account.msaId === 0) {
-              unusedKeyAccounts.set(account.address, account);
-            }
-            nonProviderAccounts.set(account.address, account);
-          }
-        }
-      })
-    );
+  } catch (e) {
+    console.error('Unable to load extension accounts', e);
   }
-
-  providerAccountsStore.set(providerAccounts);
-  nonProviderAccountsStore.set(nonProviderAccounts);
-  unusedKeyAccountsStore.set(unusedKeyAccounts);
   allAccountsStore.set(allAccounts);
 }

--- a/src/lib/stores/networksStore.ts
+++ b/src/lib/stores/networksStore.ts
@@ -16,9 +16,14 @@ export const allNetworks = writable<NetworkInfo[]>([
     genesisHash: '0x4a587bf17a404e3572747add7aab7bbe56e805a5479c6c436f07f36fcc8d3ae1',
   },
   {
-    name: 'TESTNET',
+    name: 'TESTNET_ROCOCO',
     endpoint: 'wss://rpc.rococo.frequency.xyz',
     genesisHash: '0x0c33dfffa907de5683ae21cc6b4af899b5c4de83f3794ed75b2dc74e1b088e72',
+  },
+  {
+    name: 'TESTNET_PASEO',
+    endpoint: 'wss://0.rpc.testnet.amplica.io',
+    genesisHash: '0x203c6838fc78ea3660a2f298a58d859519c72a5efdc0f194abd6f0d5ce1838e0',
   },
   { name: 'LOCALHOST', endpoint: 'ws://127.0.0.1:9944' },
   { name: 'CUSTOM' },

--- a/src/routes/faq/+page.svelte
+++ b/src/routes/faq/+page.svelte
@@ -7,11 +7,12 @@
   <h2 class="section-title">FAQ's</h2>
 
   <FAQItem>
-    <span slot="question">What is the difference between Mainnet and Testnet (Rococo)?</span>
+    <span slot="question">What is the difference between Mainnet and Testnets?</span>
     <div slot="answer" class="column">
       <p>
-        The Frequency Mainnet is the production Frequency blockchain network. The Frequency Rococo Testnet, which works
-        with the Polkadot Rococo Testnet, is for developers to test and debug applications without risking real assets.
+        The Frequency Mainnet is the production Frequency blockchain network. The Frequency Testnets, which work with
+        the Polkadot Rococo Testnet and Paseo Testnet relay chains, are for developers to test and debug applications
+        without risking real assets.
       </p>
       <p>What about the other options?</p>
       <ul class="unordered-list">

--- a/test/unit-and-integration/accountsStore.test.ts
+++ b/test/unit-and-integration/accountsStore.test.ts
@@ -1,0 +1,66 @@
+import Keyring from '@polkadot/keyring';
+import {
+  allAccountsStore,
+  providerAccountsStore,
+  nonProviderAccountsStore,
+  unusedKeyAccountsStore,
+  Account,
+} from '../../src/lib/stores/accountsStore';
+import { KeyringPair } from '@polkadot/keyring/types';
+import { get } from 'svelte/store';
+
+describe('derived stores have the correct data', () => {
+  const keyring = new Keyring({ type: 'sr25519' });
+  const alice: KeyringPair = { ...keyring.addFromUri('//Alice'), ...{ meta: { name: '//Alice' } } };
+  const bob: KeyringPair = { ...keyring.addFromUri('//Bob'), ...{ meta: { name: '//Bob' } } };
+  const charlie: KeyringPair = { ...keyring.addFromUri('//Charlie'), ...{ meta: { name: '//Charlie' } } };
+
+  beforeAll(() => {
+    const provider: Account = {
+      address: alice.address,
+      isProvider: true,
+      msaId: 1,
+      providerName: 'test',
+      keyringPair: alice,
+    };
+    const msaOnly: Account = {
+      address: bob.address,
+      isProvider: false,
+      msaId: 2,
+      keyringPair: bob,
+    };
+    const unused: Account = {
+      address: charlie.address,
+      isProvider: false,
+      msaId: 0,
+      keyringPair: charlie,
+    };
+    allAccountsStore.set(
+      new Map([
+        [provider.address, provider],
+        [msaOnly.address, msaOnly],
+        [unused.address, unused],
+      ])
+    );
+  });
+  it('allAccountsStore', () => {
+    const accounts = get(allAccountsStore);
+    expect(accounts.size).toBe(3);
+  });
+  it('providerAccountsStore', () => {
+    const accounts = get(providerAccountsStore);
+    expect(accounts.size).toBe(1);
+    expect(accounts.get(alice.address)).not.toBeUndefined();
+  });
+  it('nonProviderAccountsStore', () => {
+    const accounts = get(nonProviderAccountsStore);
+    expect(accounts.size).toBe(2);
+    expect(accounts.get(bob.address)).not.toBeUndefined();
+    expect(accounts.get(charlie.address)).not.toBeUndefined();
+  });
+  it('unusedKeyAccountsStore', () => {
+    const accounts = get(unusedKeyAccountsStore);
+    expect(accounts.size).toBe(1);
+    expect(accounts.get(charlie.address)).not.toBeUndefined();
+  });
+});

--- a/test/unit-and-integration/createMsa.test.ts
+++ b/test/unit-and-integration/createMsa.test.ts
@@ -2,13 +2,12 @@ import { storeChainInfo } from '../../src/lib/stores';
 import '@testing-library/jest-dom';
 import CreateMsa from '../../src/components/CreateMsa.svelte';
 import { vi } from 'vitest';
-import { fireEvent, render, waitFor } from '@testing-library/svelte';
+import { fireEvent, render } from '@testing-library/svelte';
 
 globalThis.alert = () => {};
 
 describe('CreateMsa component', () => {
   const mockCancelAction = vi.fn();
-  const mockBeforeCreate = vi.fn();
 
   beforeAll(() => {
     storeChainInfo.update((val) => (val = { ...val, connected: true }));

--- a/test/unit-and-integration/provider.test.ts
+++ b/test/unit-and-integration/provider.test.ts
@@ -1,6 +1,6 @@
 import { cleanup, render } from '@testing-library/svelte';
 import '@testing-library/jest-dom';
-import { dotApi, storeChainInfo } from '../../src/lib/stores';
+import { storeChainInfo } from '../../src/lib/stores';
 import { user } from '../../src/lib/stores/userStore';
 import Provider from '$components/Provider.svelte';
 import { getByTextContent } from '../helpers';

--- a/test/unit-and-integration/stake.test.ts
+++ b/test/unit-and-integration/stake.test.ts
@@ -1,6 +1,7 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
 import '@testing-library/jest-dom';
 import { dotApi, storeChainInfo } from '../../src/lib/stores';
+import { Account, allAccountsStore } from '../../src/lib/stores/accountsStore';
 import Stake, { stakeAmount } from '$components/Stake.svelte';
 import { user } from '../../src/lib/stores/userStore';
 import { KeyringPair } from '@polkadot/keyring/types';
@@ -39,9 +40,17 @@ describe('Stake.svelte Unit Tests', () => {
 
   beforeEach(() => {
     const keyring = new Keyring({ type: 'sr25519' });
-    const keyRingPair: KeyringPair = { ...keyring.addFromUri('//Alice'), ...{ meta: { name: '//Alice' } } };
+    const keyringPair: KeyringPair = { ...keyring.addFromUri('//Alice'), ...{ meta: { name: '//Alice' } } };
 
-    user.set({ address: '', isProvider: true, msaId: 1, providerName: 'test', signingKey: keyRingPair });
+    const account: Account = {
+      address: keyringPair.address,
+      isProvider: true,
+      msaId: 1,
+      providerName: 'test',
+      keyringPair,
+    };
+    user.set(account);
+    allAccountsStore.set(new Map([[account.address, account]]));
   });
   afterEach(() => cleanup());
 
@@ -69,7 +78,7 @@ describe('Stake.svelte Unit Tests', () => {
     storeChainInfo.update((val) => (val = { ...val, connected: true }));
 
     render(Stake, { isOpen: true });
-    await dotApi.update((val) => (val = { ...val, api: createdApi }));
+    dotApi.update((val) => (val = { ...val, api: createdApi }));
 
     const button = screen.getByRole('button', { name: 'Stake' });
 

--- a/test/unit-and-integration/utils.test.ts
+++ b/test/unit-and-integration/utils.test.ts
@@ -8,6 +8,7 @@ describe('isLocalhost', () => {
     expect(isLocalhost('ws://localhost:9944')).toBe(true);
     expect(isLocalhost('wss://0.rpc.frequency.xyz')).toBe(false);
     expect(isLocalhost('wss://rpc.rococo.frequency.xyz')).toBe(false);
+    expect(isLocalhost('wss://0.rpc.testnet.amplica.io')).toBe(false);
   });
 });
 describe('isMainnet', () => {
@@ -15,6 +16,7 @@ describe('isMainnet', () => {
     expect(isMainnet('wss://0.rpc.frequency.xyz')).toBe(true);
     expect(isMainnet('wss://1.rpc.frequency.xyz')).toBe(true);
     expect(isMainnet('wss://rpc.rococo.frequency.xyz')).toBe(false);
+    expect(isMainnet('wss://0.rpc.testnet.amplica.io')).toBe(false);
     expect(isMainnet('http://localhost:8080')).toBe(false);
     expect(isMainnet('wss://127.0.0.1:8080')).toBe(false);
     expect(isMainnet('http://localhost')).toBe(false);


### PR DESCRIPTION
- Support for Paseo
- Wrap some wallet extension calls in try-catch to prevent failures when non are there
- Add a display to the account so one can more easily pick out accounts that are not providers
- Make the account store a single store with three derived stores instead of trying to process them all separately